### PR TITLE
BOTC: Sync role data with official script tool

### DIFF
--- a/apps/botc/src/components/script/NightFirstSetup.tsx
+++ b/apps/botc/src/components/script/NightFirstSetup.tsx
@@ -31,7 +31,7 @@ export function NightFirstSetup({ roles, scriptName }: NightFirstSetupProps) {
   const dawn = {
     id: 'dawn',
     name: tContent('Dawn'),
-    firstNight: 73,
+    firstNight: 77,
     image: (
       <Avatar
         fallback={<Sun size={24} />}
@@ -46,7 +46,7 @@ export function NightFirstSetup({ roles, scriptName }: NightFirstSetupProps) {
   const minionInfo = {
     id: 'minion-info',
     name: tContent('Info for Minion'),
-    firstNight: 15,
+    firstNight: 19,
     image: <Avatar fallback="M" size="4" radius="full" />,
     reminder: tContent(
       'If there are 7 or more players, wake all Minions: Show the THIS IS THE DEMON token. Point to the Demon. Show the THESE ARE YOUR MINIONS token. Point to the other Minions.',
@@ -56,7 +56,7 @@ export function NightFirstSetup({ roles, scriptName }: NightFirstSetupProps) {
   const demonInfo = {
     id: 'demon-info',
     name: tContent('Info for Demon'),
-    firstNight: 19,
+    firstNight: 23,
     image: <Avatar fallback="D" size="4" radius="full" />,
     reminder: tContent(
       'If there are 7 or more players, wake the Demon: Show the THESE ARE YOUR MINIONS token. Point to all Minions. Show the THESE CHARACTERS ARE NOT IN PLAY token. Show 3 not-in-play good character tokens.',

--- a/apps/botc/src/components/script/NightOtherSetup.tsx
+++ b/apps/botc/src/components/script/NightOtherSetup.tsx
@@ -34,7 +34,7 @@ export function NightOtherSetup({ roles, scriptName }: NightOtherSetupProps) {
     id: 'dawn',
     name: tContent('Dawn'),
     firstNight: 53,
-    otherNight: 94,
+    otherNight: 98,
     image: (
       <Avatar
         fallback={<Sun size={24} />}

--- a/apps/botc/src/data/roles.en.ts
+++ b/apps/botc/src/data/roles.en.ts
@@ -14,7 +14,7 @@ export const roles = [
     name: 'Alchemist',
     edition: '',
     team: 'townsfolk',
-    firstNight: 11,
+    firstNight: 15,
     firstNightReminder:
       'Show the YOU ARE info token and a Minion token.',
     otherNight: 0,
@@ -50,10 +50,10 @@ export const roles = [
     name: 'Amnesiac',
     edition: '',
     team: 'townsfolk',
-    firstNight: 46,
+    firstNight: 50,
     firstNightReminder:
       "Do whatever needs to be done to satisfy the Amnesiac's ability.",
-    otherNight: 67,
+    otherNight: 69,
     otherNightReminder:
       "Do whatever needs to be done to satisfy the Amnesiac's ability.",
     reminders: ['?'],
@@ -98,10 +98,10 @@ export const roles = [
     name: 'Balloonist',
     edition: '',
     team: 'townsfolk',
-    firstNight: 61,
+    firstNight: 65,
     firstNightReminder:
       "Point to any player. ⏺",
-    otherNight: 82,
+    otherNight: 85,
     otherNightReminder:
       "Point to a player with a different character type to the previously shown player. ⏺",
     reminders: [
@@ -122,10 +122,10 @@ export const roles = [
     name: 'Bounty Hunter',
     edition: '',
     team: 'townsfolk',
-    firstNight: 64,
+    firstNight: 68,
     firstNightReminder:
       "Point to the player marked KNOW. ",
-    otherNight: 85,
+    otherNight: 88,
     otherNightReminder:
       'If the player marked KNOW died today or tonight, point to the new player marked KNOW.',
     reminders: ['Known'],
@@ -156,10 +156,10 @@ export const roles = [
     name: 'Chambermaid',
     edition: 'bmr',
     team: 'townsfolk',
-    firstNight: 71,
+    firstNight: 75,
     firstNightReminder:
       'The Chambermaid chooses 2 living players. Give a finger signal.',
-    otherNight: 92,
+    otherNight: 95,
     otherNightReminder:
       'The Chambermaid chooses 2 living players. Give a finger signal.',
     reminders: [],
@@ -173,7 +173,7 @@ export const roles = [
     name: 'Chef',
     edition: 'tb',
     team: 'townsfolk',
-    firstNight: 50,
+    firstNight: 54,
     firstNightReminder:
       'Give a finger signal.',
     otherNight: 0,
@@ -191,7 +191,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 64,
+    otherNight: 66,
     otherNightReminder:
       'If the Demon killed the King, point to the Demon player.',
     reminders: [],
@@ -206,7 +206,7 @@ export const roles = [
     name: 'Clockmaker',
     edition: 'snv',
     team: 'townsfolk',
-    firstNight: 55,
+    firstNight: 59,
     firstNightReminder:
       'Give a finger signal.',
     otherNight: 0,
@@ -223,10 +223,10 @@ export const roles = [
     name: 'Courtier',
     edition: 'bmr',
     team: 'townsfolk',
-    firstNight: 30,
+    firstNight: 34,
     firstNightReminder:
       "The Courtier might choose a character. ⏺ ⏺",
-    otherNight: 16,
+    otherNight: 18,
     otherNightReminder:
       "The Courtier might choose a character. ⏺ ⏺",
     reminders: ['Drunk 3', 'Drunk 2', 'Drunk 1', 'No ability'],
@@ -241,10 +241,10 @@ export const roles = [
     name: 'Cult Leader',
     edition: '',
     team: 'townsfolk',
-    firstNight: 66,
+    firstNight: 70,
     firstNightReminder:
       'The Cult Leader might change alignment. If so, show the YOU ARE info token & give a thumb signal.',
-    otherNight: 87,
+    otherNight: 90,
     otherNightReminder:
       'The Cult Leader might change alignment. If so, show the YOU ARE info token & give a thumb signal.',
     reminders: [],
@@ -258,10 +258,10 @@ export const roles = [
     name: 'Dreamer',
     edition: 'snv',
     team: 'townsfolk',
-    firstNight: 56,
+    firstNight: 60,
     firstNightReminder:
       'The Dreamer points to a player. Show 1 good & 1 evil character token, 1 of which is their character.',
-    otherNight: 76,
+    otherNight: 79,
     otherNightReminder:
       'The Dreamer points to a player. Show 1 good & 1 evil character token, 1 of which is their character.',
     reminders: [],
@@ -275,10 +275,10 @@ export const roles = [
     name: 'Empath',
     edition: 'tb',
     team: 'townsfolk',
-    firstNight: 51,
+    firstNight: 55,
     firstNightReminder:
       'Give a finger signal.',
-    otherNight: 73,
+    otherNight: 76,
     otherNightReminder:
       'Give a finger signal.',
     reminders: [],
@@ -293,10 +293,10 @@ export const roles = [
     name: 'Engineer',
     edition: '',
     team: 'townsfolk',
-    firstNight: 23,
+    firstNight: 27,
     firstNightReminder:
       "The Engineer might choose Minions or Demons. Put the Engineer to sleep. Wake the target(s) one at a time. Show the YOU ARE info token & their new character token. ⏺",
-    otherNight: 12,
+    otherNight: 14,
     otherNightReminder:
       "The Engineer might choose Minions or Demons. Put the Engineer to sleep. Wake the target(s) one at a time. Show the YOU ARE info token & their new character token. ⏺",
     reminders: ['No ability'],
@@ -313,7 +313,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 34,
+    otherNight: 36,
     otherNightReminder:
       'The Exorcist chooses a player. ⏺ Put the Exorcist to sleep. If the Exorcist chose the Demon: Wake the Demon. Show the THIS CHARACTER SELECTED YOU & Exorcist tokens. Point to the Exorcist.',
     reminders: ['Chosen'],
@@ -329,7 +329,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 68,
+    otherNight: 70,
     otherNightReminder:
       "If the Farmer died tonight, wake a living good player. Show the YOU ARE info token and a Farmer token.",
     reminders: [],
@@ -361,7 +361,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 77,
+    otherNight: 80,
     otherNightReminder:
       "Either nod or shake your head.",
     reminders: ['Demon voted', 'Demon not voted'],
@@ -389,10 +389,10 @@ export const roles = [
     name: 'Fortune Teller',
     edition: 'tb',
     team: 'townsfolk',
-    firstNight: 52,
+    firstNight: 56,
     firstNightReminder:
       'The Fortune Teller chooses 2 players. Nod if either is the Demon (or the RED HERRING).',
-    otherNight: 74,
+    otherNight: 77,
     otherNightReminder:
       "The Fortune Teller chooses 2 players. Nod if either is the Demon (or the RED HERRING).",
     reminders: ['Red herring'],
@@ -408,7 +408,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 19,
+    otherNight: 21,
     otherNightReminder:
       'The Gambler chooses a player & a character. ⏺',
     reminders: ['Dead'],
@@ -422,10 +422,10 @@ export const roles = [
     name: 'General',
     edition: '',
     team: 'townsfolk',
-    firstNight: 70,
+    firstNight: 74,
     firstNightReminder:
       'Give a thumb signal.',
-    otherNight: 91,
+    otherNight: 94,
     otherNightReminder:
       'Give a thumb signal.',
     reminders: [],
@@ -441,7 +441,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 56,
+    otherNight: 58,
     otherNightReminder:
       'If the Gossip is due to kill a player, they die. ⏺',
     reminders: ['Dead'],
@@ -456,10 +456,10 @@ export const roles = [
     name: 'Grandmother',
     edition: 'bmr',
     team: 'townsfolk',
-    firstNight: 54,
+    firstNight: 58,
     firstNightReminder:
       'Point to the grandchild player & show their character token.',
-    otherNight: 71,
+    otherNight: 73,
     otherNightReminder:
       'If the grandchild was killed by the Demon, the Grandmother dies too. ⏺',
     reminders: ['Grandchild'],
@@ -474,10 +474,10 @@ export const roles = [
     name: 'Huntsman',
     edition: '',
     team: 'townsfolk',
-    firstNight: 44,
+    firstNight: 48,
     firstNightReminder:
       "The Huntsman might choose a player. ⏺ If they chose the Damsel: Put the Huntsman to sleep. Wake the target. Show the YOU ARE info token & their new character token.",
-    otherNight: 65,
+    otherNight: 67,
     otherNightReminder:
       "The Huntsman might choose a player. ⏺ If they chose the Damsel: Put the Huntsman to sleep. Wake the target. Show the YOU ARE info token & their new character token.",
     reminders: ['No ability'],
@@ -494,7 +494,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 17,
+    otherNight: 19,
     otherNightReminder:
       'The Innkeeper chooses 2 players. ⏺ ⏺ ⏺',
     reminders: ['Protected', 'Drunk'],
@@ -509,7 +509,7 @@ export const roles = [
     name: 'Investigator',
     edition: 'tb',
     team: 'townsfolk',
-    firstNight: 49,
+    firstNight: 53,
     firstNightReminder:
       'Show the Minion character token. Point to both the MINION and WRONG players.',
     otherNight: 0,
@@ -526,7 +526,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 81,
+    otherNight: 84,
     otherNightReminder:
       "Give a finger signal.",
     reminders: ['Correct'],
@@ -540,10 +540,10 @@ export const roles = [
     name: 'King',
     edition: '',
     team: 'townsfolk',
-    firstNight: 20,
+    firstNight: 24,
     firstNightReminder:
       "Wake the Demon: Show the THIS PLAYER IS & King tokens, then point to the King.",
-    otherNight: 84,
+    otherNight: 87,
     otherNightReminder:
       'If the dead equal or outnumber the living, show the character token of a living player.',
     reminders: [],
@@ -558,7 +558,7 @@ export const roles = [
     name: 'Librarian',
     edition: 'tb',
     team: 'townsfolk',
-    firstNight: 48,
+    firstNight: 52,
     firstNightReminder:
       'Show the Outsider character token. Point to both the OUTSIDER and WRONG players.',
     otherNight: 0,
@@ -577,7 +577,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 35,
+    otherNight: 37,
     otherNightReminder:
       'The Lycanthrope chooses a player. ⏺',
     reminders: ['Dead'],
@@ -592,7 +592,7 @@ export const roles = [
     name: 'Magician',
     edition: '',
     team: 'townsfolk',
-    firstNight: 14,
+    firstNight: 18,
     firstNightReminder: 'During Minion Info, point to the Magician and the Demon. During Demon Info, point to the Magician and the Minions.',
     otherNight: 0,
     otherNightReminder: '',
@@ -608,10 +608,10 @@ export const roles = [
     name: 'Mathematician',
     edition: 'snv',
     team: 'townsfolk',
-    firstNight: 72,
+    firstNight: 76,
     firstNightReminder:
       'Give a finger signal.',
-    otherNight: 93,
+    otherNight: 96,
     otherNightReminder:
       'Give a finger signal.',
     reminders: ['Abnormal'],
@@ -658,7 +658,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 22,
+    otherNight: 24,
     otherNightReminder:
       "The Monk chooses a player. ⏺",
     reminders: ['Protected'],
@@ -673,10 +673,10 @@ export const roles = [
     name: 'Nightwatchman',
     edition: '',
     team: 'townsfolk',
-    firstNight: 65,
+    firstNight: 69,
     firstNightReminder:
       "The Nightwatchman might choose a player. Put the Nightwatchman to sleep. Wake the target. Show the THIS PLAYER IS & Nightwatchman tokens, then point to the Nightwatchman. ⏺",
-    otherNight: 86,
+    otherNight: 89,
     otherNightReminder:
       "The Nightwatchman might choose a player. Put the Nightwatchman to sleep. Wake the target. Show the THIS PLAYER IS & Nightwatchman tokens, then point to the Nightwatchman. ⏺",
     reminders: ['No ability'],
@@ -690,7 +690,7 @@ export const roles = [
     name: 'Noble',
     edition: '',
     team: 'townsfolk',
-    firstNight: 60,
+    firstNight: 64,
     firstNightReminder:
       'Point to the 3 players marked KNOW.',
     otherNight: 0,
@@ -707,7 +707,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 79,
+    otherNight: 82,
     otherNightReminder:
       'Give a finger signal.',
     reminders: [],
@@ -736,10 +736,10 @@ export const roles = [
     name: 'Philosopher',
     edition: 'snv',
     team: 'townsfolk',
-    firstNight: 10,
+    firstNight: 14,
     firstNightReminder:
       "The Philosopher might choose a character. If necessary, swap their character token. ⏺",
-    otherNight: 9,
+    otherNight: 11,
     otherNightReminder:
       "The Philosopher might choose a character. If necessary, swap their character token. ⏺",
     reminders: ['Drunk', 'Is the Philosopher'],
@@ -753,7 +753,7 @@ export const roles = [
     name: 'Pixie',
     edition: '',
     team: 'townsfolk',
-    firstNight: 43,
+    firstNight: 47,
     firstNightReminder: 'Show the Townsfolk character token marked MAD.',
     otherNight: 0,
     otherNightReminder: '',
@@ -769,9 +769,9 @@ export const roles = [
     name: 'Poppy Grower',
     edition: '',
     team: 'townsfolk',
-    firstNight: 12,
+    firstNight: 16,
     firstNightReminder: 'Skip Minion Info and Demon Info. Wake the Demon. Show the THESE CHARACTERS ARE NOT IN PLAY token. Show 3 not-in-play good character tokens.',
-    otherNight: 10,
+    otherNight: 12,
     otherNightReminder:
       'If the Poppy Grower died today or tonight, wake all Minions. Show the THIS IS THE DEMON token. Point to the Demon. Put the Minions to sleep. Wake the Demon. Show the THESE ARE YOUR MINIONS token. Point to the Minions.',
     reminders: ['Evil wakes'],
@@ -786,10 +786,10 @@ export const roles = [
     name: 'Preacher',
     edition: '',
     team: 'townsfolk',
-    firstNight: 24,
+    firstNight: 28,
     firstNightReminder:
       "The Preacher chooses a player. ⏺ If they chose a Minion: Put the Preacher to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU & Preacher tokens.",
-    otherNight: 13,
+    otherNight: 15,
     otherNightReminder:
       "The Preacher chooses a player. ⏺ If they chose a Minion: Put the Preacher to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU & Preacher tokens.",
     reminders: ['At a sermon'],
@@ -812,7 +812,7 @@ export const roles = [
     image:
       'https://wiki.bloodontheclocktower.com/images/3/36/Icon_princess.png',
     firstNight: 0,
-    otherNight: 36,
+    otherNight: 38,
     source: 'cs',
   },
   {
@@ -824,7 +824,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 63,
+    otherNight: 65,
     otherNightReminder:
       'The Professor might choose a dead player. ⏺ ⏺',
     reminders: ['Alive', 'No ability'],
@@ -841,7 +841,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 72,
+    otherNight: 75,
     otherNightReminder:
       'If the Ravenkeeper died tonight, the Ravenkeeper chooses a player. Show that player\'s character token.',
     reminders: [],
@@ -860,7 +860,7 @@ export const roles = [
     setup: false,
     ability: 'You start knowing 2 players that are not the Demon.',
     image: 'https://wiki.bloodontheclocktower.com/images/8/8e/Icon_knight.png',
-    firstNight: 59,
+    firstNight: 63,
     otherNight: 0,
     flavor: 'When a man lies, he murders some part of the world.',
     source: 'cs',
@@ -873,7 +873,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 61,
+    otherNight: 63,
     otherNightReminder:
       'If the Demon killed the Sage, wake the Sage and point to 2 players, 1 of which is the Demon.',
     reminders: [],
@@ -886,10 +886,10 @@ export const roles = [
     name: 'Sailor',
     edition: 'bmr',
     team: 'townsfolk',
-    firstNight: 21,
+    firstNight: 25,
     firstNightReminder:
       'The Sailor chooses a living player. ⏺',
-    otherNight: 11,
+    otherNight: 13,
     otherNightReminder:
       'The Sailor chooses a living player. ⏺',
     reminders: ['Drunk'],
@@ -919,10 +919,10 @@ export const roles = [
     name: 'Seamstress',
     edition: 'snv',
     team: 'townsfolk',
-    firstNight: 57,
+    firstNight: 61,
     firstNightReminder:
       "The Seamstress might choose 2 players. Nod or shake your head. ⏺",
-    otherNight: 80,
+    otherNight: 83,
     otherNightReminder:
       "The Seamstress might choose 2 players. Nod or shake your head. ⏺",
     reminders: ['No ability'],
@@ -944,7 +944,7 @@ export const roles = [
       'You start knowing if your closest evil player is clockwise or anti-clockwise. If equidistant, this info is arbitrary.',
     image:
       'https://wiki.bloodontheclocktower.com/images/1/11/Icon_shugenja.png',
-    firstNight: 62,
+    firstNight: 66,
     otherNight: 0,
     flavor: 'これは夢。それも夢。すべて夢です。',
     source: 'cs',
@@ -978,7 +978,7 @@ export const roles = [
       'If the Demon kills you, all players learn this. From now on, you may nominate twice per day and vote twice per nomination.',
     image: 'https://wiki.bloodontheclocktower.com/images/6/63/Icon_banshee.png',
     firstNight: 0,
-    otherNight: 62,
+    otherNight: 64,
     flavor:
       'Gorm do shúile, dearg do ghruaig, ní bheidh sé i bhfad, is a mbeidh tú san uaigh.',
     source: 'cs',
@@ -990,10 +990,10 @@ export const roles = [
     name: 'Snake Charmer',
     edition: 'snv',
     team: 'townsfolk',
-    firstNight: 32,
+    firstNight: 36,
     firstNightReminder:
       'The Snake Charmer chooses a player. If they chose the Demon: Show the YOU ARE & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the YOU ARE and Snake Charmer tokens & give a thumbs up. ⏺',
-    otherNight: 21,
+    otherNight: 23,
     otherNightReminder:
       'The Snake Charmer chooses a player. If they chose the Demon: Show the YOU ARE & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the YOU ARE and Snake Charmer tokens & give a thumbs up. ⏺',
     reminders: ['Poisoned'],
@@ -1026,7 +1026,7 @@ export const roles = [
     setup: false,
     ability: 'You start knowing 1 good player.',
     image: 'https://wiki.bloodontheclocktower.com/images/f/fe/Icon_steward.png',
-    firstNight: 58,
+    firstNight: 62,
     otherNight: 0,
     flavor:
       'How DARE you accuse Her Ladyship of wrongdoing? I’ve known her my entire life! All nine years!',
@@ -1055,7 +1055,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 78,
+    otherNight: 81,
     otherNightReminder:
       "Either nod or shake your head.",
     reminders: ['Minions not nominated', 'Minion nominated'],
@@ -1071,7 +1071,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 75,
+    otherNight: 78,
     otherNightReminder:
       'If a player was executed today, show their character token.',
     reminders: ['Executed'],
@@ -1091,8 +1091,8 @@ export const roles = [
       'Each night, learn which player the Storyteller believes you should talk to most.',
     image:
       'https://wiki.bloodontheclocktower.com/images/6/63/Icon_highpriestess.png',
-    firstNight: 69,
-    otherNight: 90,
+    firstNight: 73,
+    otherNight: 93,
     flavor:
       'There is life behind the personality that uses personalities as masks. There are times when life puts off the mask and deep answers to deep.',
     source: 'cs',
@@ -1112,8 +1112,8 @@ export const roles = [
       'Each night, choose a player: you learn their alignment. [+0 to +2 Village Idiots. 1 of the extras is drunk]',
     image:
       'https://wiki.bloodontheclocktower.com/images/d/da/Icon_villageidiot.png',
-    firstNight: 63,
-    otherNight: 83,
+    firstNight: 67,
+    otherNight: 86,
     special: [
       {
         type: 'selection',
@@ -1146,7 +1146,7 @@ export const roles = [
     name: 'Washerwoman',
     edition: 'tb',
     team: 'townsfolk',
-    firstNight: 47,
+    firstNight: 51,
     firstNightReminder:
       'Show the Townsfolk character token. Point to both the TOWNSFOLK and WRONG players.',
     otherNight: 0,
@@ -1163,7 +1163,7 @@ export const roles = [
     team: 'outsider',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 20,
+    otherNight: 22,
     otherNightReminder:
       'The Acrobat chooses a player. ⏺',
     reminders: ['Dead'],
@@ -1179,7 +1179,7 @@ export const roles = [
     team: 'outsider',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 58,
+    otherNight: 60,
     otherNightReminder:
       "If the Barber died today or tonight, show the Demon the THIS CHARACTER SELECTED YOU & Barber tokens. If the Demon chose 2 players, wake one at a time. Show the YOU ARE token & their new character token.",
     reminders: ['Haircuts tonight'],
@@ -1193,10 +1193,10 @@ export const roles = [
     name: 'Butler',
     edition: 'tb',
     team: 'outsider',
-    firstNight: 53,
+    firstNight: 57,
     firstNightReminder:
       "The Butler chooses a player. ⏺",
-    otherNight: 88,
+    otherNight: 91,
     otherNightReminder:
       "The Butler chooses a player. ⏺",
     reminders: ['Master'],
@@ -1210,10 +1210,10 @@ export const roles = [
     name: 'Damsel',
     edition: '',
     team: 'outsider',
-    firstNight: 45,
+    firstNight: 49,
     firstNightReminder:
       "During Minion Info, show the Minions the Damsel token. If you haven't done this yet, do so now. If the Damsel was chosen by the Huntsman, show the YOU ARE info token & their new character token.",
-    otherNight: 66,
+    otherNight: 68,
     otherNightReminder:
       "If the Damsel was chosen by the Huntsman, show the YOU ARE info token & their new character token.",
     reminders: ['Guess used'],
@@ -1281,7 +1281,7 @@ export const roles = [
       'If you died today or tonight, the Minion & Demon players may choose new Minion & Demon characters to be.',
     image: 'https://wiki.bloodontheclocktower.com/images/4/44/Icon_hatter.png',
     firstNight: 0,
-    otherNight: 57,
+    otherNight: 59,
     flavor:
       'One Hat. Too Hat. Three Hat. Tea Hat. Fore Hat. Thrive Hat. Six Hat. Sticks Hat.',
     source: 'cs',
@@ -1321,10 +1321,10 @@ export const roles = [
     name: 'Lunatic',
     edition: 'bmr',
     team: 'outsider',
-    firstNight: 17,
+    firstNight: 21,
     firstNightReminder:
       "If there are 7 or more players, wake the Lunatic: Show the THESE ARE YOUR MINIONS token. Point to any players. Show the THESE CHARACTERS ARE NOT IN PLAY token. Show 3 good character tokens. Put the Lunatic to sleep. Wake the Demon. Show the YOU ARE info token and the Demon token. Show the THIS PLAYER IS info token and the Lunatic token, then point to the Lunatic.",
-    otherNight: 33,
+    otherNight: 35,
     otherNightReminder:
       "Do whatever needs to be done to simulate the Demon acting. Put the Lunatic to sleep. Wake the Demon. Show the Lunatic token & point to them, then their target(s).",
     reminders: ['Attack 1', 'Attack 2', 'Attack 3'],
@@ -1341,7 +1341,7 @@ export const roles = [
     team: 'outsider',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 70,
+    otherNight: 72,
     otherNightReminder:
       'If the Moonchild is due to kill a good player, they die. ⏺',
     reminders: ['Dead'],
@@ -1362,7 +1362,7 @@ export const roles = [
     image:
       'https://wiki.bloodontheclocktower.com/images/e/e2/Icon_plaguedoctor.png',
     firstNight: 0,
-    otherNight: 60,
+    otherNight: 62,
     flavor: 'Pleauze shtay shtill. Thinks nid tiime for hillink. Myrhh-myrhh.',
     source: 'cs',
   },
@@ -1461,7 +1461,7 @@ export const roles = [
     name: 'Snitch',
     edition: '',
     team: 'outsider',
-    firstNight: 16,
+    firstNight: 20,
     firstNightReminder:
       'Wake each Minion. Show the THESE CHARACTERS ARE NOT IN PLAY token. Show 3 not-in-play character tokens.',
     otherNight: 0,
@@ -1479,7 +1479,7 @@ export const roles = [
     team: 'outsider',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 59,
+    otherNight: 61,
     otherNightReminder: 'If the Sweetheart died, a player became drunk immediately. If you haven\'t done this yet, do so now. ⏺',
     reminders: ['Drunk'],
     setup: false,
@@ -1493,7 +1493,7 @@ export const roles = [
     team: 'outsider',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 69,
+    otherNight: 71,
     otherNightReminder: 'The Tinker might die. ⏺',
     reminders: ['Dead'],
     setup: false,
@@ -1530,7 +1530,7 @@ export const roles = [
     ability:
       "On your 1st night, choose a player (not yourself): you become their alignment (you don't know which) even if drunk or poisoned.",
     image: 'https://wiki.bloodontheclocktower.com/images/2/25/Icon_ogre.png',
-    firstNight: 68,
+    firstNight: 72,
     otherNight: 0,
     flavor: '<grunt><grin></grunt>',
     source: 'cs',
@@ -1544,7 +1544,7 @@ export const roles = [
     team: 'minion',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 54,
+    otherNight: 56,
     otherNightReminder:
       "The Assassin might choose a player. ⏺ ⏺",
     reminders: ['Dead', 'No ability'],
@@ -1579,7 +1579,7 @@ export const roles = [
     ability:
       "The Demon (even if drunk or poisoned) has a not-in-play good character’s ability. You both know which.",
     image: 'https://wiki.bloodontheclocktower.com/images/e/e0/Icon_boffin.png',
-    firstNight: 9,
+    firstNight: 13,
     otherNight: 0,
     flavor:
       'Stellar hydrogen, vast, inert; carbon, oxygen, neon gases, all ruined. Molecular chaos, entropy, yields new cosmic phenomena, rebirth from atomic chaos, dense matter collapsing. All in a teeny little bottle.',
@@ -1615,8 +1615,8 @@ export const roles = [
     ability:
       'Once per game, choose to make a wish. If granted, it might have a price & leave a clue as to its nature.',
     image: 'https://wiki.bloodontheclocktower.com/images/b/b5/Icon_wizard.png',
-    firstNight: 31,
-    otherNight: 18,
+    firstNight: 35,
+    otherNight: 20,
     flavor:
       'Every man and every woman is a star. Love is the law, love under will.',
     source: 'cs',
@@ -1628,10 +1628,10 @@ export const roles = [
     name: 'Cerenovus',
     edition: 'snv',
     team: 'minion',
-    firstNight: 38,
+    firstNight: 42,
     firstNightReminder:
       "The Cerenovus chooses a player & a character. ⏺ Put the Cerenovus to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU token, the Cerenovus token, then the madness-character token.",
-    otherNight: 26,
+    otherNight: 28,
     otherNightReminder:
       "The Cerenovus chooses a player & a character. ⏺ Put the Cerenovus to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU token, the Cerenovus token, then the madness-character token.",
     reminders: ['Mad'],
@@ -1660,8 +1660,8 @@ export const roles = [
       'All players keep their eyes closed when voting and the vote tally is secret. Each night, choose if you are drunk until dusk.',
     image:
       'https://wiki.bloodontheclocktower.com/images/6/61/Icon_organgrinder.png',
-    firstNight: 34,
-    otherNight: 23,
+    firstNight: 38,
+    otherNight: 25,
     flavor:
       'Round and round the handles go. The more you dance the less you know.',
     source: 'cs',
@@ -1673,10 +1673,10 @@ export const roles = [
     name: "Devil's Advocate",
     edition: 'bmr',
     team: 'minion',
-    firstNight: 35,
+    firstNight: 39,
     firstNightReminder:
       'The Devil\'s Advocate chooses a living player. ⏺',
-    otherNight: 24,
+    otherNight: 26,
     otherNightReminder:
       'The Devil\'s Advocate chooses a living player. ⏺',
     reminders: ['Survives execution'],
@@ -1691,7 +1691,7 @@ export const roles = [
     name: 'Evil Twin',
     edition: 'snv',
     team: 'minion',
-    firstNight: 36,
+    firstNight: 40,
     firstNightReminder:
       'Wake both twins. Allow eye contact. Show the good twin\'s character token to the Evil Twin & vice versa.',
     otherNight: 0,
@@ -1708,10 +1708,10 @@ export const roles = [
     name: 'Fearmonger',
     edition: '',
     team: 'minion',
-    firstNight: 39,
+    firstNight: 43,
     firstNightReminder:
       'The Fearmonger chooses a player. ⏺ Announce that the Fearmonger has chosen a player.',
-    otherNight: 28,
+    otherNight: 30,
     otherNightReminder:
       'The Fearmonger chooses a player. ⏺ If the target is different to last night, announce that the Fearmonger has chosen a player.',
     reminders: ['Fear'],
@@ -1741,9 +1741,9 @@ export const roles = [
     name: 'Godfather',
     edition: 'bmr',
     team: 'minion',
-    firstNight: 33,
+    firstNight: 37,
     firstNightReminder: 'Show the character tokens of all in-play Outsiders.',
-    otherNight: 55,
+    otherNight: 57,
     otherNightReminder:
       'If an Outsider died today, the Godfather chooses a player. ⏺',
     reminders: ['Died today', 'Dead'],
@@ -1765,8 +1765,8 @@ export const roles = [
     ability:
       'Each night, choose 2 players: tomorrow, the 1st player is mad that the 2nd is evil, or one or both might die.',
     image: 'https://wiki.bloodontheclocktower.com/images/d/d3/Icon_harpy.png',
-    firstNight: 40,
-    otherNight: 29,
+    firstNight: 44,
+    otherNight: 31,
     flavor:
       'So fair a day I never did see, nor so fowl a presence hanging over me.',
     source: 'cs',
@@ -1778,7 +1778,7 @@ export const roles = [
     name: 'Marionette',
     edition: '',
     team: 'minion',
-    firstNight: 22,
+    firstNight: 26,
     firstNightReminder:
       'Wake the Demon. Show the THIS PLAYER IS & Marionette tokens. Point to the Marionette.',
     otherNight: 0,
@@ -1812,9 +1812,9 @@ export const roles = [
     name: 'Mezepheles',
     edition: '',
     team: 'minion',
-    firstNight: 41,
+    firstNight: 45,
     firstNightReminder: 'Show the secret word.',
-    otherNight: 30,
+    otherNight: 32,
     otherNightReminder:
       "If a good player said the secret word, wake the player. Show the YOU ARE info token & give a thumbs-down. ⏺ ⏺",
     reminders: ['Turns evil', 'No ability'],
@@ -1830,7 +1830,7 @@ export const roles = [
     team: 'minion',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 27,
+    otherNight: 29,
     otherNightReminder:
       "The Pit-Hag chooses a player & a character. If they chose a character that is not in play: Put the Pit-Hag to sleep. Wake the target. Show the YOU ARE token & their new character token.",
     reminders: [],
@@ -1845,10 +1845,10 @@ export const roles = [
     name: 'Poisoner',
     edition: 'tb',
     team: 'minion',
-    firstNight: 28,
+    firstNight: 32,
     firstNightReminder:
       'The Poisoner chooses a player. ⏺',
-    otherNight: 15,
+    otherNight: 17,
     otherNightReminder:
       'The Poisoner chooses a player. ⏺',
     reminders: ['Poisoned'],
@@ -1877,8 +1877,8 @@ export const roles = [
     ability:
       'You may choose to open your eyes at night. You wake when other evil players do.',
     image: 'https://wiki.bloodontheclocktower.com/images/8/8f/Icon_wraith.png',
-    firstNight: 2,
-    otherNight: 2,
+    firstNight: 6,
+    otherNight: 4,
     source: 'cs',
   },
   {
@@ -1906,7 +1906,7 @@ export const roles = [
     team: 'minion',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 31,
+    otherNight: 33,
     otherNightReminder:
       "If the Scarlet Woman became the Demon today, show them the YOU ARE token, then the Demon token.",
     reminders: ['Demon'],
@@ -1920,10 +1920,10 @@ export const roles = [
     name: 'Spy',
     edition: 'tb',
     team: 'minion',
-    firstNight: 67,
+    firstNight: 71,
     firstNightReminder:
       'Show the Grimoire for as long as the Spy needs.',
-    otherNight: 89,
+    otherNight: 92,
     otherNightReminder:
       'Show the Grimoire for as long as the Spy needs.',
     reminders: [],
@@ -1946,8 +1946,8 @@ export const roles = [
       'You get 3 bluffs. On the 3rd night, choose a player: they become an evil Demon of your choice. [No Demon]',
     image:
       'https://wiki.bloodontheclocktower.com/images/1/1a/Icon_summoner.png',
-    firstNight: 18,
-    otherNight: 32,
+    firstNight: 22,
+    otherNight: 34,
     flavor:
       'Hail the guardians of the north; by my intellect, thou art cut. Hail the guardians of the east; by my will, thou art dominated. Hail the guardians of the south; by that which lies beyond, the mystery is revealed. Hail the guardians of the west; a shield in the darkness',
     source: 'cs',
@@ -1964,7 +1964,7 @@ export const roles = [
     ability:
       'All players know you are the Vizier. You cannot die during the day. If good voted, you may choose to execute immediately.',
     image: 'https://wiki.bloodontheclocktower.com/images/a/a4/Icon_vizier.png',
-    firstNight: 75,
+    firstNight: 79,
     otherNight: 0,
     flavor:
       'An excellent decision, as always, sire. Such a petty crime as bumping into the Bishop indeed deserves your ‘justice’ and ‘mercy’. Take a stroll in the gardens. Visit the gallery and peruse the sculptures of Von Strauf. Relax, sire. Leave everything… to me.',
@@ -1976,7 +1976,7 @@ export const roles = [
     name: 'Widow',
     edition: '',
     team: 'minion',
-    firstNight: 29,
+    firstNight: 33,
     firstNightReminder:
       "Show the Grimoire for as long as the Widow needs. The Widow chooses a player. ⏺ Put the Widow to sleep. Wake the player marked KNOW & show the Widow token. ⏺",
     otherNight: 0,
@@ -1993,10 +1993,10 @@ export const roles = [
     name: 'Witch',
     edition: 'snv',
     team: 'minion',
-    firstNight: 37,
+    firstNight: 41,
     firstNightReminder:
       'The Witch chooses a player. ⏺',
-    otherNight: 25,
+    otherNight: 27,
     otherNightReminder:
       'The Witch chooses a player. ⏺',
     reminders: ['Cursed'],
@@ -2017,8 +2017,8 @@ export const roles = [
     setup: true,
     ability: 'On night X, all Townsfolk are poisoned until dusk. [X Outsiders]',
     image: 'https://wiki.bloodontheclocktower.com/images/0/0c/Icon_xaan.png',
-    firstNight: 27,
-    otherNight: 14,
+    firstNight: 31,
+    otherNight: 16,
     flavor: 'Down they fall. One by one. By two, by three, by five.',
     source: 'cs',
   },
@@ -2031,7 +2031,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 49,
+    otherNight: 51,
     otherNightReminder:
       'The Al-Hadikhia chooses 3 players. ⏺ ⏺ ⏺ In order, wake each target. They nod or shake their head. Put them to sleep before waking the next target.',
     reminders: ['1', '2', '3', 'Chose death', 'Chose life'],
@@ -2053,8 +2053,8 @@ export const roles = [
       'You start knowing a secret phrase. For each time you said it publicly today, a player might die.',
     image:
       'https://wiki.bloodontheclocktower.com/images/0/08/Icon_yaggababble.png',
-    firstNight: 13,
-    otherNight: 52,
+    firstNight: 17,
+    otherNight: 54,
     flavor:
       'Murders inside the Rue Morgue? Фальшивые новости! Hounds on the Baskerville moor? Фальшивые новости! Death while sailing the Nile? Фальшивые новости!',
     source: 'cs',
@@ -2067,7 +2067,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 43,
+    otherNight: 45,
     otherNightReminder:
       "The Fang Gu chooses a player. ⏺ If they chose an Outsider (once only): Replace the Outsider token with the spare Fang Gu token. Put the Fang Gu to sleep. Wake the target. Show the YOU ARE and Fang Gu tokens & give a thumbs-down. ⏺",
     reminders: ['Dead', 'Once'],
@@ -2083,7 +2083,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 38,
+    otherNight: 40,
     otherNightReminder:
       "The Imp chooses a player. ⏺ If the Imp chose themselves: Replace 1 alive Minion token with a spare Imp token. Put the old Imp to sleep. Wake the new Imp. Show the YOU ARE token, then show the Imp token.",
     reminders: ['Dead'],
@@ -2104,8 +2104,8 @@ export const roles = [
     ability:
       'Each night*, choose a player: they die. [You choose which players are which Minions. -? to +? Outsiders]',
     image: 'https://wiki.bloodontheclocktower.com/images/3/3c/Icon_kazali.png',
-    firstNight: 4,
-    otherNight: 53,
+    firstNight: 8,
+    otherNight: 55,
     flavor:
       'Gon(z)a7les6. Take cau8tun. The mech4an4ion is iNvert10d. E99ors insy6tum. Reco{7}fig.',
     source: 'cs',
@@ -2118,7 +2118,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 37,
+    otherNight: 39,
     otherNightReminder: 'A player might die. ⏺',
     reminders: ['Dead', 'About to die'],
     setup: true,
@@ -2132,10 +2132,10 @@ export const roles = [
     name: 'Leviathan',
     edition: '',
     team: 'demon',
-    firstNight: 74,
+    firstNight: 78,
     firstNightReminder:
       "Announce that the Leviathan is in play. ⏺",
-    otherNight: 95,
+    otherNight: 99,
     otherNightReminder: 'Change the Leviathan reminder token to the relevant day. ⏺ You may announce that the Leviathan is in play.',
     reminders: [
       'Day 1',
@@ -2156,10 +2156,10 @@ export const roles = [
     name: "Lil' Monsta",
     edition: '',
     team: 'demon',
-    firstNight: 25,
+    firstNight: 29,
     firstNightReminder:
       "Wake the Minions. They choose a player. ⏺ Put the Minions to sleep. Wake the target. Show the YOU ARE & Lil' Monsta tokens.",
-    otherNight: 51,
+    otherNight: 53,
     otherNightReminder:
       "Wake the Minions. They choose a player. ⏺ Put the Minions to sleep. Wake the target. Show the YOU ARE & Lil' Monsta tokens. A player might die. ⏺",
     reminders: [],
@@ -2174,10 +2174,10 @@ export const roles = [
     name: 'Lleech',
     edition: '',
     team: 'demon',
-    firstNight: 26,
+    firstNight: 30,
     firstNightReminder:
       'The Lleech chooses a player. ⏺',
-    otherNight: 50,
+    otherNight: 52,
     otherNightReminder: 'The Lleech chooses a player. ⏺',
     reminders: ['Dead', 'Poisoned'],
     setup: false,
@@ -2193,7 +2193,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 44,
+    otherNight: 46,
     otherNightReminder: 'The No Dashii chooses a player. ⏺',
     reminders: ['Dead', 'Poisoned'],
     setup: false,
@@ -2214,7 +2214,7 @@ export const roles = [
       'Each night*, choose a character: they die. If they are not in play, the Storyteller chooses who dies.',
     image: 'https://wiki.bloodontheclocktower.com/images/6/6f/Icon_ojo.png',
     firstNight: 0,
-    otherNight: 48,
+    otherNight: 50,
     flavor: 'Like a bonfire on a moonless night… I see you, mortal.',
     source: 'cs',
   },
@@ -2233,8 +2233,8 @@ export const roles = [
       'Each night*, choose a player: they die. [Evil characters are in a line. You are in the middle. +1 Minion. -? to +? Outsiders]',
     image:
       'https://wiki.bloodontheclocktower.com/images/c/cf/Icon_lordoftyphon.png',
-    firstNight: 3,
-    otherNight: 46,
+    firstNight: 7,
+    otherNight: 48,
     flavor:
       'In the shadowed and forgotten corners of the cosmos, where the stars whisper secrets to the void, lies a truth so profound that the merest glimpse of it unravels the sanity of mortal minds.',
     source: 'cs',
@@ -2247,7 +2247,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 42,
+    otherNight: 44,
     otherNightReminder:
       "The Po may choose a player OR chooses 3 players if they chose no-one last night. ⏺ or ⏺ ⏺ ⏺",
     reminders: ['Dead', '3 attacks'],
@@ -2261,10 +2261,10 @@ export const roles = [
     name: 'Pukka',
     edition: 'bmr',
     team: 'demon',
-    firstNight: 42,
+    firstNight: 46,
     firstNightReminder:
       'The Pukka chooses a player. ⏺',
-    otherNight: 40,
+    otherNight: 42,
     otherNightReminder:
       'The Pukka chooses a player. ⏺ The previously poisoned player dies then becomes healthy. ⏺',
     reminders: ['Poisoned', 'Dead'],
@@ -2280,7 +2280,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 0,
+    otherNight: 97,
     otherNightReminder: 'Change the Riot reminder token to the relevant day. ⏺ If it is night 3, you may wake the Minions. Show the YOU ARE & Riot tokens.',
     reminders: [],
     setup: false,
@@ -2296,7 +2296,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 41,
+    otherNight: 43,
     otherNightReminder:
       'A previously chosen player might be resurrected. ⏺ The Shabaloth chooses 2 players. ⏺ ⏺',
     reminders: ['Dead', 'Alive'],
@@ -2313,7 +2313,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 47,
+    otherNight: 49,
     otherNightReminder:
       'The Vigormortis chooses a player. ⏺ If that player is a Minion, poison a neighboring Townsfolk. ⏺ ⏺',
     reminders: ['Dead', 'Has ability', 'Poisoned'],
@@ -2329,7 +2329,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 45,
+    otherNight: 47,
     otherNightReminder: 'The Vortox chooses a player. ⏺',
     reminders: ['Dead'],
     setup: false,
@@ -2344,7 +2344,7 @@ export const roles = [
     team: 'demon',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 39,
+    otherNight: 41,
     otherNightReminder:
       'If no one died today, the Zombuul chooses a player. ⏺',
     reminders: ['Died today', 'Dead'],
@@ -2359,7 +2359,7 @@ export const roles = [
     name: 'Apprentice',
     edition: 'bmr',
     team: 'traveler',
-    firstNight: 5,
+    firstNight: 9,
     firstNightReminder:
       "Show the YOU ARE info token, then a Townsfolk or Minion token. Swap the Apprentice & Townsfolk or Minion tokens. ⏺",
     otherNight: 0,
@@ -2375,10 +2375,10 @@ export const roles = [
     name: 'Barista',
     edition: 'snv',
     team: 'traveler',
-    firstNight: 6,
+    firstNight: 10,
     firstNightReminder:
       'Choose a player. Wake them, show the THIS CHARACTER SELECTED YOU & Barista tokens, then give a finger signal. ⏺',
-    otherNight: 4,
+    otherNight: 6,
     otherNightReminder:
       'Choose a player. Wake them, show the THIS CHARACTER SELECTED YOU & Barista tokens, then give a finger signal. ⏺',
     reminders: ['Sober & Healthy', 'Ability twice'],
@@ -2425,7 +2425,7 @@ export const roles = [
     team: 'traveler',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 8,
+    otherNight: 10,
     otherNightReminder:
       "The Bone Collector might choose a dead player. ⏺ If necessary, wake the chosen player to use their ability.",
     reminders: ['No ability', 'Has ability'],
@@ -2440,10 +2440,10 @@ export const roles = [
     name: 'Bureaucrat',
     edition: 'tb',
     team: 'traveler',
-    firstNight: 7,
+    firstNight: 11,
     firstNightReminder:
       "The Bureaucrat chooses a player. ⏺",
-    otherNight: 5,
+    otherNight: 7,
     otherNightReminder:
       "The Bureaucrat chooses a player. ⏺",
     reminders: ['3 votes'],
@@ -2480,7 +2480,7 @@ export const roles = [
     image:
       'https://wiki.bloodontheclocktower.com/images/d/d7/Icon_cacklejack.png',
     firstNight: 0,
-    otherNight: 3,
+    otherNight: 5,
     source: 'cs',
   },
   {
@@ -2555,7 +2555,7 @@ export const roles = [
     team: 'traveler',
     firstNight: 0,
     firstNightReminder: '',
-    otherNight: 7,
+    otherNight: 9,
     otherNightReminder:
       "The Harlot chooses a living player. Put the Harlot to sleep. Wake the chosen player, show them the THIS CHARACTER SELECTED YOU token, then the Harlot token. If that player nods their head, wake the Harlot and show them the chosen player's character token. Both players might die. ⏺ ⏺",
     reminders: ['Dead'],
@@ -2615,10 +2615,10 @@ export const roles = [
     name: 'Thief',
     edition: 'tb',
     team: 'traveler',
-    firstNight: 8,
+    firstNight: 12,
     firstNightReminder:
       "The Thief chooses a player. ⏺",
-    otherNight: 6,
+    otherNight: 8,
     otherNightReminder:
       "The Thief chooses a player. ⏺",
     reminders: ['Negative vote'],
@@ -2657,7 +2657,7 @@ export const roles = [
       'With thunder as my voice and lightning as my blade, I, the eternal guardian, feast upon the fools who dare approach the forbidden gate. Behold, my sacred goal! To purge the beetle from the belly of the rocky earth, to ensnare it in a net of stars on the hilltop where heaven meets earth.',
     image: 'https://wiki.bloodontheclocktower.com/images/6/61/Icon_tor.png',
     firstNight: 0,
-    otherNight: 50,
+    otherNight: 74,
     source: 'cs',
   },
   {
@@ -2717,7 +2717,7 @@ export const roles = [
     name: 'Storm Catcher',
     edition: '',
     team: 'loric',
-    firstNight: 14,
+    firstNight: 5,
     firstNightReminder:
       'Announce which character is stormcaught. If that character is in play, mark that player as STORMCAUGHT. Wake each evil player and show them the character token, then the marked player.  If not in play, wake each evil player, show them the THESE CHARACTERS ARE NOT IN PLAY token & the relevant character token.',
     otherNight: 0,
@@ -2805,7 +2805,7 @@ export const roles = [
     setup: false,
     name: 'Angel',
     edition: '',
-    firstNight: 0,
+    firstNight: 2,
     otherNight: 0,
     team: 'fabled',
     ability:
@@ -2820,7 +2820,7 @@ export const roles = [
     setup: false,
     name: 'Buddhist',
     edition: '',
-    firstNight: 0,
+    firstNight: 3,
     otherNight: 0,
     team: 'fabled',
     ability:
@@ -2878,14 +2878,14 @@ export const roles = [
   {
     id: 'toymaker',
     firstNightReminder: 'Resolve Minion Info and Demon Info, even though there are fewer than 7 players.',
-    otherNight: 1,
+    otherNight: 3,
     otherNightReminder:
       'If a Demon attack could end the game, and the Demon is marked *FINAL NIGHT: NO ATTACK*, do not wake the Demon.',
     reminders: ['Final Night: No Attack'],
     setup: false,
     name: 'Toymaker',
     edition: '',
-    firstNight: 0,
+    firstNight: 4,
     team: 'fabled',
     ability:
       'The Demon may choose not to attack & must do this at least once per game. Evil players get normal starting info.',
@@ -2909,7 +2909,7 @@ export const roles = [
   {
     id: 'duchess',
     firstNightReminder: '',
-    otherNight: 1,
+    otherNight: 2,
     otherNightReminder:
       'One at a time: Wake each player marked VISITOR or FALSE INFO. Show the THIS CHARACTER SELECTED YOU & Duchess tokens, then give a finger signal.',
     reminders: ['Visitor', 'False Info'],

--- a/apps/botc/src/data/roles.en.ts
+++ b/apps/botc/src/data/roles.en.ts
@@ -16,7 +16,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 11,
     firstNightReminder:
-      'Show the YOU ARE token and the character token of a Minion.',
+      'Show the *YOU ARE* info token and a Minion token.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
@@ -52,10 +52,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 46,
     firstNightReminder:
-      "Decide the Amnesiac's entire ability. If the Amnesiac's ability causes them to wake tonight: Wake the Amnesiac and run their ability.",
+      "Do whatever needs to be done to satisfy the Amnesiac's ability.",
     otherNight: 67,
     otherNightReminder:
-      "If the Amnesiac's ability causes them to wake tonight: Wake the Amnesiac and run their ability.",
+      "Do whatever needs to be done to satisfy the Amnesiac's ability.",
     reminders: ['?'],
     setup: false,
     ability:
@@ -89,7 +89,7 @@ export const roles = [
     reminders: [],
     setup: true,
     ability:
-      'The Storyteller can break the game rules & if executed, good wins, even if you are dead. [No evil characters]',
+      'The Storyteller can break the game rules, and if executed, good wins, even if you are dead. [No evil characters]',
   },
   {
     id: 'balloonist',
@@ -100,10 +100,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 61,
     firstNightReminder:
-      "Choose a character type. Point to a player whose character is of that type. Place the Balloonist's Seen reminder next to that character.",
+      "Point to any player. :reminder:",
     otherNight: 82,
     otherNightReminder:
-      "Choose a character type that does not yet have a Seen reminder next to a character of that type. Point to a player whose character is of that type, if there are any. Place the Balloonist's Seen reminder next to that character.",
+      "Point to a player with a different character type to the previously shown player. :reminder:",
     reminders: [
       'Seen Townsfolk',
       'Seen Outsider',
@@ -113,7 +113,7 @@ export const roles = [
     ],
     setup: true,
     ability:
-      'Each night, you learn 1 player of each character type, until there are no more types to learn. [+1 Outsider]',
+      'Each night, you learn a player of a different character type than last night. [+0 or +1 Outsider]',
   },
   {
     id: 'bountyhunter',
@@ -124,10 +124,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 64,
     firstNightReminder:
-      "Point to 1 evil player. Wake the townsfolk who is evil and show them the 'You are' card and the thumbs down evil sign.",
+      "Point to the player marked *KNOW*. ",
     otherNight: 85,
     otherNightReminder:
-      'If the known evil player has died, point to another evil player. ',
+      'If the player marked *KNOW* died today or tonight, point to the new player marked *KNOW*.',
     reminders: ['Known'],
     setup: true,
     ability:
@@ -158,10 +158,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 71,
     firstNightReminder:
-      'The Chambermaid points to two players. Show the number signal (0, 1, 2, …) for how many of those players wake tonight for their ability.',
+      'The Chambermaid chooses 2 living players. Give a finger signal.',
     otherNight: 92,
     otherNightReminder:
-      'The Chambermaid points to two players. Show the number signal (0, 1, 2, …) for how many of those players wake tonight for their ability.',
+      'The Chambermaid chooses 2 living players. Give a finger signal.',
     reminders: [],
     setup: false,
     ability:
@@ -175,7 +175,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 50,
     firstNightReminder:
-      'Show the finger signal (0, 1, 2, …) for the number of pairs of neighbouring evil players.',
+      'Give a finger signal.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
@@ -193,11 +193,11 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 64,
     otherNightReminder:
-      'If the King was killed by the Demon, wake the Choirboy and point to the Demon player.',
+      'If the Demon killed the King, point to the Demon player.',
     reminders: [],
     setup: true,
     ability:
-      'If the Demon kills the King, you learn which player is the Demon. [+ the King]',
+      'If the Demon kills the King, you learn which player is the Demon. [+the King]',
   },
   {
     id: 'clockmaker',
@@ -208,7 +208,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 55,
     firstNightReminder:
-      'Show the hand signal for the number (1, 2, 3, etc.) of places from Demon to closest Minion.',
+      'Give a finger signal.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
@@ -225,10 +225,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 30,
     firstNightReminder:
-      "The Courtier either shows a 'no' head signal, or points to a character on the sheet. If the Courtier used their ability: If that character is in play, that player is drunk.",
+      "The Courtier might choose a character. :reminder: :reminder:",
     otherNight: 16,
     otherNightReminder:
-      "Reduce the remaining number of days the marked player is poisoned. If the Courtier has not yet used their ability: The Courtier either shows a 'no' head signal, or points to a character on the sheet. If the Courtier used their ability: If that character is in play, that player is drunk.",
+      "The Courtier might choose a character. :reminder: :reminder:",
     reminders: ['Drunk 3', 'Drunk 2', 'Drunk 1', 'No ability'],
     setup: false,
     ability:
@@ -243,14 +243,14 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 66,
     firstNightReminder:
-      'If the cult leader changed alignment, show them the thumbs up good signal of the thumbs down evil signal accordingly.',
+      'The Cult Leader might change alignment. If so, show the *YOU ARE* info token & give a thumb signal.',
     otherNight: 87,
     otherNightReminder:
-      'If the cult leader changed alignment, show them the thumbs up good signal of the thumbs down evil signal accordingly.',
+      'The Cult Leader might change alignment. If so, show the *YOU ARE* info token & give a thumb signal.',
     reminders: [],
     setup: false,
     ability:
-      'Each night, you become the alignment of an alive neighbour. If all good players choose to join your cult, your team wins.',
+      'Each night, you become the alignment of an alive neighbor. If all good players choose to join your cult, your team wins.',
   },
   {
     id: 'dreamer',
@@ -260,14 +260,14 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 56,
     firstNightReminder:
-      'The Dreamer points to a player. Show 1 good and 1 evil character token; one of these is correct.',
+      'The Dreamer points to a player. Show 1 good & 1 evil character token, 1 of which is their character.',
     otherNight: 76,
     otherNightReminder:
-      'The Dreamer points to a player. Show 1 good and 1 evil character token; one of these is correct.',
+      'The Dreamer points to a player. Show 1 good & 1 evil character token, 1 of which is their character.',
     reminders: [],
     setup: false,
     ability:
-      'Each night, choose a player (not yourself or travelers): you learn 1 good and 1 evil character, 1 of which is correct.',
+      'Each night, choose a player (not yourself or Travellers): you learn 1 good & 1 evil character, 1 of which is correct.',
   },
   {
     id: 'empath',
@@ -277,14 +277,14 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 51,
     firstNightReminder:
-      'Show the finger signal (0, 1, 2) for the number of evil alive neighbours of the Empath.',
+      'Give a finger signal.',
     otherNight: 73,
     otherNightReminder:
-      'Show the finger signal (0, 1, 2) for the number of evil neighbours.',
+      'Give a finger signal.',
     reminders: [],
     setup: false,
     ability:
-      'Each night, you learn how many of your 2 alive neighbours are evil.',
+      'Each night, you learn how many of your 2 alive neighbors are evil.',
   },
   {
     id: 'engineer',
@@ -295,10 +295,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 23,
     firstNightReminder:
-      "The Engineer shows a 'no' head signal, or points to a Demon or points to the relevant number of Minions. If the Engineer chose characters, replace the Demon or Minions with the choices, then wake the relevant players and show them the You are card and the relevant character tokens.",
+      "The Engineer might choose Minions or Demons. Put the Engineer to sleep. Wake the target(s) one at a time. Show the *YOU ARE* info token & their new character token. :reminder:",
     otherNight: 12,
     otherNightReminder:
-      "The Engineer shows a 'no' head signal, or points to a Demon or points to the relevant number of Minions. If the Engineer chose characters, replace the Demon or Minions with the choices, then wake the relevant players and show them the 'You are' card and the relevant character tokens.",
+      "The Engineer might choose Minions or Demons. Put the Engineer to sleep. Wake the target(s) one at a time. Show the *YOU ARE* info token & their new character token. :reminder:",
     reminders: ['No ability'],
     setup: false,
     ability:
@@ -315,7 +315,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 34,
     otherNightReminder:
-      'The Exorcist points to a player, different from the previous night. If that player is the Demon: Wake the Demon. Show the Exorcist token. Point to the Exorcist. The Demon does not act tonight.',
+      'The Exorcist chooses a player. :reminder: Put the Exorcist to sleep. If the Exorcist chose the Demon: Wake the Demon. Show the *THIS CHARACTER SELECTED YOU* & Exorcist tokens. Point to the Exorcist.',
     reminders: ['Chosen'],
     setup: false,
     ability:
@@ -331,10 +331,10 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 68,
     otherNightReminder:
-      "If a Farmer died tonight, choose another good player and make them the Farmer. Wake this player, show them the 'You are' card and the Farmer character token.",
+      "If the Farmer died tonight, wake a living good player. Show the *YOU ARE* info token and a Farmer token.",
     reminders: [],
     setup: false,
-    ability: 'If you die at night, an alive good player becomes a Farmer.',
+    ability: 'When you die at night, an alive good player becomes a Farmer.',
   },
   {
     id: 'fisherman',
@@ -350,7 +350,7 @@ export const roles = [
     reminders: ['No ability'],
     setup: false,
     ability:
-      'Once per game, during the day, visit the Storyteller for some advice to help you win.',
+      'Once per game, during the day, visit the Storyteller for some advice to help your team win.',
   },
   {
     id: 'flowergirl',
@@ -363,7 +363,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 77,
     otherNightReminder:
-      "Nod 'yes' or shake head 'no' for whether the Demon voted today. Place the 'Demon not voted' marker (remove 'Demon voted', if any).",
+      "Either nod or shake your head.",
     reminders: ['Demon voted', 'Demon not voted'],
     setup: false,
     ability: 'Each night*, you learn if a Demon voted today.',
@@ -380,7 +380,7 @@ export const roles = [
     otherNightReminder: '',
     reminders: ['No ability'],
     setup: false,
-    ability: "The first time you die, you don't.",
+    ability: "The 1st time you die, you don't.",
   },
   {
     id: 'fortuneteller',
@@ -391,10 +391,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 52,
     firstNightReminder:
-      'The Fortune Teller points to two players. Give the head signal (nod yes, shake no) for whether one of those players is the Demon. ',
+      'The Fortune Teller chooses 2 players. Nod if either is the Demon (or the *RED HERRING*).',
     otherNight: 74,
     otherNightReminder:
-      "The Fortune Teller points to two players. Show the head signal (nod 'yes', shake 'no') for whether one of those players is the Demon.",
+      "The Fortune Teller chooses 2 players. Nod if either is the Demon (or the *RED HERRING*).",
     reminders: ['Red herring'],
     setup: false,
     ability:
@@ -410,7 +410,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 19,
     otherNightReminder:
-      'The Gambler points to a player, and a character on their sheet. If incorrect, the Gambler dies.',
+      'The Gambler chooses a player & a character. :reminder:',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -424,10 +424,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 70,
     firstNightReminder:
-      'Show the General thumbs up for good winning, thumbs down for evil winning or thumb to the side for neither.',
+      'Give a thumb signal.',
     otherNight: 91,
     otherNightReminder:
-      'Show the General thumbs up for good winning, thumbs down for evil winning or thumb to the side for neither.',
+      'Give a thumb signal.',
     reminders: [],
     setup: false,
     ability:
@@ -443,7 +443,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 56,
     otherNightReminder:
-      'If the Gossip’s public statement was true: Choose a player not protected from dying tonight. That player dies.',
+      'If the Gossip is due to kill a player, they die. :reminder:',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -458,10 +458,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 54,
     firstNightReminder:
-      'Show the marked character token. Point to the marked player.',
+      'Point to the grandchild player & show their character token.',
     otherNight: 71,
     otherNightReminder:
-      'If the Grandmother’s grandchild was killed by the Demon tonight: The Grandmother dies.',
+      'If the grandchild was killed by the Demon, the Grandmother dies too. :reminder:',
     reminders: ['Grandchild'],
     setup: false,
     ability:
@@ -476,10 +476,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 44,
     firstNightReminder:
-      "The Huntsman shakes their head 'no' or points to a player. If they point to the Damsel, wake that player, show the 'You are' card and a not-in-play character token.",
+      "The Huntsman might choose a player. :reminder: If they chose the Damsel: Put the Huntsman to sleep. Wake the target. Show the *YOU ARE* info token & their new character token.",
     otherNight: 65,
     otherNightReminder:
-      "The Huntsman shakes their head 'no' or points to a player. If they point to the Damsel, wake that player, show the 'You are' card and a not-in-play character token.",
+      "The Huntsman might choose a player. :reminder: If they chose the Damsel: Put the Huntsman to sleep. Wake the target. Show the *YOU ARE* info token & their new character token.",
     reminders: ['No ability'],
     setup: true,
     ability:
@@ -496,7 +496,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 17,
     otherNightReminder:
-      'The previously protected and drunk players lose those markers. The Innkeeper points to two players. Those players are protected. One is drunk.',
+      'The Innkeeper chooses 2 players. :reminder: :reminder: :reminder:',
     reminders: ['Protected', 'Drunk'],
     setup: false,
     ability:
@@ -511,7 +511,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 49,
     firstNightReminder:
-      'Show the character token of a Minion in play. Point to two players, one of which is that character.',
+      'Show the Minion character token. Point to both the *MINION* and *WRONG* players.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Minion', 'Wrong'],
@@ -528,7 +528,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 81,
     otherNightReminder:
-      "If today was the Juggler’s first day: Show the hand signal for the number (0, 1, 2, etc.) of 'Correct' markers. Remove markers.",
+      "Give a finger signal.",
     reminders: ['Correct'],
     setup: false,
     ability:
@@ -542,14 +542,14 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 20,
     firstNightReminder:
-      "Wake the Demon, show them the 'This character selected you' card, show the King token and point to the King player.",
+      "Wake the Demon: Show the *THIS PLAYER IS* & King tokens, then point to the King.",
     otherNight: 84,
     otherNightReminder:
-      'If there are more dead than living, show the King a character token of a living player.',
+      'If the dead equal or outnumber the living, show the character token of a living player.',
     reminders: [],
     setup: false,
     ability:
-      'Each night, if the dead outnumber the living, you learn 1 alive character. The Demon knows who you are.',
+      'Each night, if the dead equal or outnumber the living, you learn 1 alive character. The Demon knows you are the King.',
   },
   {
     id: 'librarian',
@@ -560,7 +560,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 48,
     firstNightReminder:
-      'Show the character token of an Outsider in play. Point to two players, one of which is that character.',
+      'Show the Outsider character token. Point to both the *OUTSIDER* and *WRONG* players.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Outsider', 'Wrong'],
@@ -579,11 +579,11 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 35,
     otherNightReminder:
-      'The Lycanthrope points to a living player: if good, they die and no one else can die tonight.',
+      'The Lycanthrope chooses a player. :reminder:',
     reminders: ['Dead'],
     setup: false,
     ability:
-      'Each night*, choose a living player: if good, they die, but they are the only player that can die tonight.',
+      'Each night*, choose an alive player. If good, they die & the Demon doesn’t kill tonight. One good player registers as evil.',
   },
   {
     id: 'magician',
@@ -593,7 +593,7 @@ export const roles = [
     edition: '',
     team: 'townsfolk',
     firstNight: 14,
-    firstNightReminder: '',
+    firstNightReminder: 'During Minion Info, point to the Magician and the Demon. During Demon Info, point to the Magician and the Minions.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
@@ -610,10 +610,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 72,
     firstNightReminder:
-      'Show the hand signal for the number (0, 1, 2, etc.) of players whose ability malfunctioned due to other abilities.',
+      'Give a finger signal.',
     otherNight: 93,
     otherNightReminder:
-      'Show the hand signal for the number (0, 1, 2, etc.) of players whose ability malfunctioned due to other abilities.',
+      'Give a finger signal.',
     reminders: ['Abnormal'],
     setup: false,
     ability:
@@ -648,7 +648,7 @@ export const roles = [
     reminders: ['Everyone drunk'],
     setup: false,
     ability:
-      'When a Minion dies by execution, all other players (except travelers) are drunk until dusk tomorrow.',
+      'When a Minion dies by execution, all other players (except Travellers) are drunk until dusk tomorrow.',
   },
   {
     id: 'monk',
@@ -660,7 +660,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 22,
     otherNightReminder:
-      "The previously protected player is no longer protected. The Monk points to a player not themself. Mark that player 'Protected'.",
+      "The Monk chooses a player. :reminder:",
     reminders: ['Protected'],
     setup: false,
     ability:
@@ -675,14 +675,14 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 65,
     firstNightReminder:
-      "The Nightwatchman may point to a player. Wake that player, show the 'This character selected you' card and the Nightwatchman token, then point to the Nightwatchman player.",
+      "The Nightwatchman might choose a player. Put the Nightwatchman to sleep. Wake the target. Show the *THIS PLAYER IS* & Nightwatchman tokens, then point to the Nightwatchman. :reminder:",
     otherNight: 86,
     otherNightReminder:
-      "The Nightwatchman may point to a player. Wake that player, show the 'This character selected you' card and the Nightwatchman token, then point to the Nightwatchman player.",
+      "The Nightwatchman might choose a player. Put the Nightwatchman to sleep. Wake the target. Show the *THIS PLAYER IS* & Nightwatchman tokens, then point to the Nightwatchman. :reminder:",
     reminders: ['No ability'],
     setup: false,
     ability:
-      'Once per game, at night, choose a player: they learn who you are.',
+      'Once per game, at night, choose a player: they learn you are the Nightwatchman.',
   },
   {
     id: 'noble',
@@ -692,7 +692,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 60,
     firstNightReminder:
-      'Point to 3 players including one evil player, in no particular order.',
+      'Point to the 3 players marked *KNOW*.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Seen'],
@@ -709,7 +709,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 79,
     otherNightReminder:
-      'Show the hand signal for the number (0, 1, 2, etc.) of dead evil players.',
+      'Give a finger signal.',
     reminders: [],
     setup: false,
     ability: 'Each night*, you learn how many dead players are evil.',
@@ -738,10 +738,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 10,
     firstNightReminder:
-      "The Philosopher either shows a 'no' head signal, or points to a good character on their sheet. If they chose a character: Swap the out-of-play character token with the Philosopher token and add the 'Is the Philosopher' reminder. If the character is in play, place the drunk marker by that player.",
+      "The Philosopher might choose a character. If necessary, swap their character token. :reminder:",
     otherNight: 9,
     otherNightReminder:
-      "If the Philosopher has not used their ability: the Philosopher either shows a 'no' head signal, or points to a good character on their sheet. If they chose a character: Swap the out-of-play character token with the Philosopher token and add the 'Is the Philosopher' reminder. If the character is in play, place the drunk marker by that player.",
+      "The Philosopher might choose a character. If necessary, swap their character token. :reminder:",
     reminders: ['Drunk', 'Is the Philosopher'],
     setup: false,
     ability:
@@ -754,7 +754,7 @@ export const roles = [
     edition: '',
     team: 'townsfolk',
     firstNight: 43,
-    firstNightReminder: 'Show the Pixie 1 in-play Townsfolk character token.',
+    firstNightReminder: 'Show the Townsfolk character token marked *MAD*.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Mad', 'Has ability'],
@@ -770,10 +770,10 @@ export const roles = [
     edition: '',
     team: 'townsfolk',
     firstNight: 12,
-    firstNightReminder: 'Do not inform the Demon/Minions who each other are',
+    firstNightReminder: 'Skip Minion Info and Demon Info. Wake the Demon. Show the *THESE CHARACTERS ARE NOT IN PLAY* token. Show 3 not-in-play good character tokens.',
     otherNight: 10,
     otherNightReminder:
-      'If the Poppy Grower has died, show the Minions/Demon who each other are.',
+      'If the Poppy Grower died today or tonight, wake all Minions. Show the *THIS IS THE DEMON* token. Point to the Demon. Put the Minions to sleep. Wake the Demon. Show the *THESE ARE YOUR MINIONS* token. Point to the Minions.',
     reminders: ['Evil wakes'],
     setup: false,
     ability:
@@ -788,10 +788,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 24,
     firstNightReminder:
-      "The Preacher chooses a player. If a Minion is chosen, wake the Minion and show the 'This character selected you' card and then the Preacher token.",
+      "The Preacher chooses a player. :reminder: If they chose a Minion: Put the Preacher to sleep. Wake the target. Show the *THIS CHARACTER SELECTED YOU* & Preacher tokens.",
     otherNight: 13,
     otherNightReminder:
-      "The Preacher chooses a player. If a Minion is chosen, wake the Minion and show the 'This character selected you' card and then the Preacher token.",
+      "The Preacher chooses a player. :reminder: If they chose a Minion: Put the Preacher to sleep. Wake the target. Show the *THIS CHARACTER SELECTED YOU* & Preacher tokens.",
     reminders: ['At a sermon'],
     setup: false,
     ability:
@@ -804,11 +804,11 @@ export const roles = [
     team: 'townsfolk',
     firstNightReminder: '',
     otherNightReminder:
-      "If it was the Princess' first day today, and they nominated and executed a player, the Demon doesn't kill.",
+      "If the Princess nominated the player who was executed today, wake the Demon as normal, but no one dies to the Demon's ability. :reminder:",
     reminders: ["Doesn't Kill"],
     setup: false,
     ability:
-      'On your 1st day, if you nominated & executed a player, the Demon doesn’t kill tonight.',
+      'On your 1st day, if you nominated & executed a player, the Demon doesn\'t kill tonight.',
     image:
       'https://wiki.bloodontheclocktower.com/images/3/36/Icon_princess.png',
     firstNight: 0,
@@ -826,7 +826,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 63,
     otherNightReminder:
-      'If the Professor has not used their ability: The Professor either shakes their head no, or points to a player. If that player is a Townsfolk, they are now alive.',
+      'The Professor might choose a dead player. :reminder: :reminder:',
     reminders: ['Alive', 'No ability'],
     setup: false,
     ability:
@@ -843,7 +843,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 72,
     otherNightReminder:
-      'If the Ravenkeeper died tonight: The Ravenkeeper points to a player. Show that player’s character token.',
+      'If the Ravenkeeper died tonight, the Ravenkeeper chooses a player. Show that player\'s character token.',
     reminders: [],
     setup: false,
     ability:
@@ -854,7 +854,7 @@ export const roles = [
     name: 'Knight',
     edition: '',
     team: 'townsfolk',
-    firstNightReminder: 'Point to the 2 marked players.',
+    firstNightReminder: 'Point to the 2 players marked *KNOW*.',
     otherNightReminder: '',
     reminders: ['Know', 'Know'],
     setup: false,
@@ -875,7 +875,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 61,
     otherNightReminder:
-      'If the Sage was killed by a Demon: Point to two players, one of which is that Demon.',
+      'If the Demon killed the Sage, wake the Sage and point to 2 players, 1 of which is the Demon.',
     reminders: [],
     setup: false,
     ability: 'If the Demon kills you, you learn that it is 1 of 2 players.',
@@ -888,10 +888,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 21,
     firstNightReminder:
-      'The Sailor points to a living player. Either the Sailor, or the chosen player, is drunk.',
+      'The Sailor chooses a living player. :reminder:',
     otherNight: 11,
     otherNightReminder:
-      'The previously drunk player is no longer drunk. The Sailor points to a living player. Either the Sailor, or the chosen player, is drunk.',
+      'The Sailor chooses a living player. :reminder:',
     reminders: ['Drunk'],
     setup: false,
     ability:
@@ -921,10 +921,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 57,
     firstNightReminder:
-      "The Seamstress either shows a 'no' head signal, or points to two other players. If the Seamstress chose players , nod 'yes' or shake 'no' for whether they are of same alignment.",
+      "The Seamstress might choose 2 players. Nod or shake your head. :reminder:",
     otherNight: 80,
     otherNightReminder:
-      "If the Seamstress has not yet used their ability: the Seamstress either shows a 'no' head signal, or points to two other players. If the Seamstress chose players , nod 'yes' or shake 'no' for whether they are of same alignment.",
+      "The Seamstress might choose 2 players. Nod or shake your head. :reminder:",
     reminders: ['No ability'],
     setup: false,
     ability:
@@ -936,7 +936,7 @@ export const roles = [
     edition: '',
     team: 'townsfolk',
     firstNightReminder:
-      'If the closest evil player is in a clockwise direction, point your finger horizontally in that direction. If the closest evil player is in an anti-clockwise direction, point your finger horizontally in that direction. If the two closest evil players are equidistant, point your finger horizontally in either direction.',
+      'Point clockwise or anticlockwise.',
     otherNightReminder: '',
     reminders: [],
     setup: false,
@@ -971,7 +971,7 @@ export const roles = [
     team: 'townsfolk',
     firstNightReminder: '',
     otherNightReminder:
-      'If the Banshee was killed by the Demon, announce that the Banshee has died.',
+      'If the Banshee was killed by the Demon tonight, announce that the Banshee has died. :reminder:',
     reminders: ['Has Ability'],
     setup: false,
     ability:
@@ -992,10 +992,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 32,
     firstNightReminder:
-      'The Snake Charmer points to a player. If that player is the Demon: swap the Demon and Snake Charmer character and alignments. Wake each player to inform them of their new role and alignment. The new Snake Charmer is poisoned.',
+      'The Snake Charmer chooses a player. If they chose the Demon: Show the *YOU ARE* & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the *YOU ARE* and Snake Charmer tokens & give a thumbs up. :reminder:',
     otherNight: 21,
     otherNightReminder:
-      'The Snake Charmer points to a player. If that player is the Demon: swap the Demon and Snake Charmer character and alignments. Wake each player to inform them of their new role and alignment. The new Snake Charmer is poisoned.',
+      'The Snake Charmer chooses a player. If they chose the Demon: Show the *YOU ARE* & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the *YOU ARE* and Snake Charmer tokens & give a thumbs up. :reminder:',
     reminders: ['Poisoned'],
     setup: false,
     ability:
@@ -1020,7 +1020,7 @@ export const roles = [
     name: 'Steward',
     edition: '',
     team: 'townsfolk',
-    firstNightReminder: 'Point to the marked player.',
+    firstNightReminder: 'Point to the player marked *KNOW*.',
     otherNightReminder: '',
     reminders: ['Know'],
     setup: false,
@@ -1044,7 +1044,7 @@ export const roles = [
     otherNightReminder: '',
     reminders: ['Can not die'],
     setup: false,
-    ability: "If both your alive neighbours are good, they can't die.",
+    ability: "If both your alive neighbors are good, they can't die.",
   },
   {
     id: 'towncrier',
@@ -1057,7 +1057,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 78,
     otherNightReminder:
-      "Nod 'yes' or shake head 'no' for whether a Minion nominated today. Place the 'Minion not nominated' marker (remove 'Minion nominated', if any).",
+      "Either nod or shake your head.",
     reminders: ['Minions not nominated', 'Minion nominated'],
     setup: false,
     ability: 'Each night*, you learn if a Minion nominated today.',
@@ -1073,7 +1073,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 75,
     otherNightReminder:
-      'If a player was executed today: Show that player’s character token.',
+      'If a player was executed today, show their character token.',
     reminders: ['Executed'],
     setup: false,
     ability: 'Each night*, you learn which character died by execution today.',
@@ -1103,9 +1103,9 @@ export const roles = [
     edition: '',
     team: 'townsfolk',
     firstNightReminder:
-      'The Village Idiot points to a player; give a thumbs up if that player is good or a thumbs down if that player is evil.',
+      'If there are multiple Village Idiots, mark one as *DRUNK*. :reminder: Wake the Village Idiots one at a time to choose a player. Give a thumb signal.',
     otherNightReminder:
-      'The Village Idiot points to a player; give a thumbs up if that player is good or a thumbs down if that player is evil.',
+      'Wake the Village Idiots one at a time to choose a player. Give a thumb signal.',
     reminders: ['Drunk'],
     setup: true,
     ability:
@@ -1148,7 +1148,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 47,
     firstNightReminder:
-      'Show the character token of a Townsfolk in play. Point to two players, one of which is that character.',
+      'Show the Townsfolk character token. Point to both the *TOWNSFOLK* and *WRONG* players.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Townsfolk', 'Wrong'],
@@ -1165,11 +1165,11 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 20,
     otherNightReminder:
-      'If a good living neighbour is drunk or poisoned, the Acrobat player dies.',
+      'The Acrobat chooses a player. :reminder:',
     reminders: ['Dead'],
     setup: false,
     ability:
-      'Each night*, if either good living neighbour is drunk or poisoned, you die.',
+      'Each night*, choose a player: if they are or become drunk or poisoned tonight, you die.',
   },
   {
     id: 'barber',
@@ -1181,7 +1181,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 58,
     otherNightReminder:
-      "If the Barber died today: Wake the Demon. Show the 'This character selected you' card, then Barber token. The Demon either shows a 'no' head signal, or points to 2 players. If they chose players: Swap the character tokens. Wake each player. Show 'You are', then their new character token.",
+      "If the Barber died today or tonight, show the Demon the *THIS CHARACTER SELECTED YOU* & Barber tokens. If the Demon chose 2 players, wake one at a time. Show the *YOU ARE* token & their new character token.",
     reminders: ['Haircuts tonight'],
     setup: false,
     ability:
@@ -1195,10 +1195,10 @@ export const roles = [
     team: 'outsider',
     firstNight: 53,
     firstNightReminder:
-      "The Butler points to a player. Mark that player as 'Master'.",
+      "The Butler chooses a player. :reminder:",
     otherNight: 88,
     otherNightReminder:
-      "The Butler points to a player. Mark that player as 'Master'.",
+      "The Butler chooses a player. :reminder:",
     reminders: ['Master'],
     setup: false,
     ability:
@@ -1212,14 +1212,14 @@ export const roles = [
     team: 'outsider',
     firstNight: 45,
     firstNightReminder:
-      "Wake all the Minions, show them the 'This character selected you' card and the Damsel token.",
+      "During Minion Info, show the Minions the Damsel token. If you haven't done this yet, do so now. If the Damsel was chosen by the Huntsman, show the *YOU ARE* info token & their new character token.",
     otherNight: 66,
     otherNightReminder:
-      "If selected by the Huntsman, wake the Damsel, show 'You are' card and a not-in-play Townsfolk token.",
+      "If the Damsel was chosen by the Huntsman, show the *YOU ARE* info token & their new character token.",
     reminders: ['Guess used'],
     setup: false,
     ability:
-      'All Minions know you are in play. If a Minion publicly guesses you (once), your team loses.',
+      'All Minions know a Damsel is in play. If a Minion publicly guesses you (once), your team loses.',
   },
   {
     id: 'drunk',
@@ -1274,7 +1274,7 @@ export const roles = [
     team: 'outsider',
     firstNightReminder: '',
     otherNightReminder:
-      'Wake the Minions and Demon. Each player either shakes their head no or points to another character of the same type as their current character. If a second player would end up with the same character as another player, shake your head no and gesture for them to choose again. Change each player to the character they chose.',
+      'If the Hatter died, wake the Minions & Demons. Each may choose a new character. If they do, show the *YOU ARE* token & their new character token.',
     reminders: ['Tea Party Tonight'],
     setup: false,
     ability:
@@ -1323,10 +1323,10 @@ export const roles = [
     team: 'outsider',
     firstNight: 17,
     firstNightReminder:
-      "If 7 or more players: Show the Lunatic a number of arbitrary 'Minions', players equal to the number of Minions in play. Show 3 character tokens of arbitrary good characters. If the token received by the Lunatic is a Demon that would wake tonight: Allow the Lunatic to do the Demon actions. Place their 'attack' markers. Wake the Demon. Show the Demon’s real character token. Show them the Lunatic player. If the Lunatic attacked players: Show the real demon each marked player. Remove any Lunatic 'attack' markers.",
+      "If there are 7 or more players, wake the Lunatic: Show the *THESE ARE YOUR MINIONS* token. Point to any players. Show the *THESE CHARACTERS ARE NOT IN PLAY* token. Show 3 good character tokens. Put the Lunatic to sleep. Wake the Demon. Show the *YOU ARE* info token and the Demon token. Show the *THIS PLAYER IS* info token and the Lunatic token, then point to the Lunatic.",
     otherNight: 33,
     otherNightReminder:
-      "Allow the Lunatic to do the actions of the Demon. Place their 'attack' markers. If the Lunatic selected players: Wake the Demon. Show the 'attack' marker, then point to each marked player. Remove any Lunatic 'attack' markers.",
+      "Do whatever needs to be done to simulate the Demon acting. Put the Lunatic to sleep. Wake the Demon. Show the Lunatic token & point to them, then their target(s).",
     reminders: ['Attack 1', 'Attack 2', 'Attack 3'],
     setup: false,
     ability:
@@ -1343,7 +1343,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 70,
     otherNightReminder:
-      'If the Moonchild used their ability to target a player today: If that player is good, they die.',
+      'If the Moonchild is due to kill a good player, they die. :reminder:',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -1355,7 +1355,7 @@ export const roles = [
     edition: '',
     team: 'outsider',
     firstNightReminder: '',
-    otherNightReminder: '',
+    otherNightReminder: 'If the Plague Doctor died, the Storyteller gained a Minion ability. If you haven’t done this yet, do so now. :reminder:',
     reminders: ['Storyteller Ability'],
     setup: false,
     ability: 'When you die, the Storyteller gains a Minion ability.',
@@ -1463,12 +1463,12 @@ export const roles = [
     team: 'outsider',
     firstNight: 16,
     firstNightReminder:
-      'After Minion info wake each Minion and show them three not-in-play character tokens. These may be the same or different to each other and the ones shown to the Demon.',
+      'Wake each Minion. Show the *THESE CHARACTERS ARE NOT IN PLAY* token. Show 3 not-in-play character tokens.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
     setup: false,
-    ability: 'Minions start knowing 3 not-in-play characters.',
+    ability: 'Each Minion gets 3 bluffs.',
   },
   {
     id: 'sweetheart',
@@ -1480,7 +1480,7 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 59,
-    otherNightReminder: 'Choose a player that is drunk.',
+    otherNightReminder: 'If the Sweetheart died, a player became drunk immediately. If you haven\'t done this yet, do so now. :reminder:',
     reminders: ['Drunk'],
     setup: false,
     ability: 'When you die, 1 player is drunk from now on.',
@@ -1494,7 +1494,7 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 69,
-    otherNightReminder: 'The Tinker might die.',
+    otherNightReminder: 'The Tinker might die. :reminder:',
     reminders: ['Dead'],
     setup: false,
     ability: 'You might die at any time.',
@@ -1523,7 +1523,7 @@ export const roles = [
     edition: '',
     team: 'outsider',
     firstNightReminder:
-      'The Ogre points to a player (not themselves) and becomes their alignment.',
+      'The Ogre chooses a player. :reminder:',
     otherNightReminder: '',
     reminders: ['Friend'],
     setup: false,
@@ -1546,7 +1546,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 54,
     otherNightReminder:
-      "If the Assassin has not yet used their ability: The Assassin either shows the 'no' head signal, or points to a player. That player dies.",
+      "The Assassin might choose a player. :reminder: :reminder:",
     reminders: ['Dead', 'No ability'],
     setup: false,
     ability:
@@ -1572,12 +1572,12 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      'Wake the Boffin and show them the token of the good ability the Demon has. Put the Boffin back to sleep. Wake the Demon, show the Boffin token, then show the token of the good ability the Demon has.',
+      'Wake the Boffin and the Demon. Show the *THIS CHARACTER SELECTED YOU* & Boffin tokens, then the not-in-play good character token.',
     otherNightReminder: '',
     reminders: [],
     setup: false,
     ability:
-      "The Demon (even if drunk or poisoned) has a not-in-play good character's ability. You both know which.",
+      "The Demon (even if drunk or poisoned) has a not-in-play good character’s ability. You both know which.",
     image: 'https://wiki.bloodontheclocktower.com/images/e/e0/Icon_boffin.png',
     firstNight: 9,
     otherNight: 0,
@@ -1599,7 +1599,7 @@ export const roles = [
     reminders: [],
     setup: false,
     ability:
-      'If you are executed, all but 3 players die. 1 minute later, the player with the most players pointing at them dies.',
+      'If you are executed, all but 3 players die. After a 10 to 1 countdown, the player with the most players pointing at them, dies.',
   },
   {
     id: 'wizard',
@@ -1607,9 +1607,9 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      "If the Wizard's wish requires actions at night, run these.",
+      "Do whatever needs to be done to satisfy the Wizard's ability.",
     otherNightReminder:
-      "If the Wizard's wish requires actions at night, run these.",
+      "Do whatever needs to be done to satisfy the Wizard's ability.",
     reminders: ['?', '?'],
     setup: false,
     ability:
@@ -1630,10 +1630,10 @@ export const roles = [
     team: 'minion',
     firstNight: 38,
     firstNightReminder:
-      "The Cerenovus points to a player, then to a character on their sheet. Wake that player. Show the 'This character selected you' card, then the Cerenovus token. Show the selected character token. If the player is not mad about being that character tomorrow, they can be executed.",
+      "The Cerenovus chooses a player & a character. :reminder: Put the Cerenovus to sleep. Wake the target. Show the *THIS CHARACTER SELECTED YOU* token, the Cerenovus token, then the madness-character token.",
     otherNight: 26,
     otherNightReminder:
-      "The Cerenovus points to a player, then to a character on their sheet. Wake that player. Show the 'This character selected you' card, then the Cerenovus token. Show the selected character token. If the player is not mad about being that character tomorrow, they can be executed.",
+      "The Cerenovus chooses a player & a character. :reminder: Put the Cerenovus to sleep. Wake the target. Show the *THIS CHARACTER SELECTED YOU* token, the Cerenovus token, then the madness-character token.",
     reminders: ['Mad'],
     setup: false,
     ability:
@@ -1645,9 +1645,9 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      "Wake the Organ Grinder. If they give the 'yes' head signal, mark them Drunk. If they give the 'no' head signal, remove the Drunk reminder.",
+      "The Organ Grinder either nods their head yes to be drunk, or shakes their head no to be sober. :reminder:",
     otherNightReminder:
-      "Wake the Organ Grinder. If they give the 'yes' head signal, mark them Drunk. If they give the 'no' head signal, remove the Drunk reminder.",
+      "The Organ Grinder either nods their head yes to be drunk, or shakes their head no to be sober. :reminder:",
     reminders: ['About To Die', 'Drunk'],
     special: [
       {
@@ -1675,10 +1675,10 @@ export const roles = [
     team: 'minion',
     firstNight: 35,
     firstNightReminder:
-      'The Devil’s Advocate points to a living player. That player survives execution tomorrow.',
+      'The Devil\'s Advocate chooses a living player. :reminder:',
     otherNight: 24,
     otherNightReminder:
-      'The Devil’s Advocate points to a living player, different from the previous night. That player survives execution tomorrow.',
+      'The Devil\'s Advocate chooses a living player. :reminder:',
     reminders: ['Survives execution'],
     setup: false,
     ability:
@@ -1693,7 +1693,7 @@ export const roles = [
     team: 'minion',
     firstNight: 36,
     firstNightReminder:
-      'Wake the Evil Twin and their twin. Confirm that they have acknowledged each other. Point to the Evil Twin. Show their Evil Twin token to the twin player. Point to the twin. Show their character token to the Evil Twin player.',
+      'Wake both twins. Allow eye contact. Show the good twin\'s character token to the Evil Twin & vice versa.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Twin'],
@@ -1710,14 +1710,14 @@ export const roles = [
     team: 'minion',
     firstNight: 39,
     firstNightReminder:
-      'The Fearmonger points to a player. Place the Fear token next to that player and announce that a new player has been selected with the Fearmonger ability.',
+      'The Fearmonger chooses a player. :reminder: Announce that the Fearmonger has chosen a player.',
     otherNight: 28,
     otherNightReminder:
-      'The Fearmonger points to a player. If different from the previous night, place the Fear token next to that player and announce that a new player has been selected with the Fearmonger ability.',
+      'The Fearmonger chooses a player. :reminder: If the target is different to last night, announce that the Fearmonger has chosen a player.',
     reminders: ['Fear'],
     setup: false,
     ability:
-      'Each night, choose a player. If you nominate & execute them, their team loses. All players know if you choose a new player.',
+      'Each night, choose a player: if you nominate & execute them, their team loses. All players know if you choose a new player.',
   },
   {
     id: 'goblin',
@@ -1742,14 +1742,14 @@ export const roles = [
     edition: 'bmr',
     team: 'minion',
     firstNight: 33,
-    firstNightReminder: 'Show each of the Outsider tokens in play.',
+    firstNightReminder: 'Show the character tokens of all in-play Outsiders.',
     otherNight: 55,
     otherNightReminder:
-      'If an Outsider died today: The Godfather points to a player. That player dies.',
+      'If an Outsider died today, the Godfather chooses a player. :reminder:',
     reminders: ['Died today', 'Dead'],
     setup: true,
     ability:
-      'You start knowing which Outsiders are in play. If 1 died today, choose a player tonight: they die. [−1 or +1 Outsider]',
+      'You start knowing which Outsiders are in play. If 1 died today, choose a player tonight: they die. [-1 or +1 Outsider]',
   },
   {
     id: 'harpy',
@@ -1757,9 +1757,9 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      "The Harpy points to two players. Wake the 1st player the Harpy pointed to, show them the 'This character has selected you' card, show them the Harpy token, then point at the 2nd player the Harpy pointed to.",
+      "The Harpy chooses 2 players. :reminder: :reminder: Put the Harpy to sleep. Wake the 1st target. Show the *THIS CHARACTER SELECTED YOU* token, the Harpy token, then point to the 2nd target.",
     otherNightReminder:
-      "The Harpy points to two players. Wake the 1st player the Harpy pointed to, show them the 'This character has selected you' card, show them the Harpy token, then point at the 2nd player the Harpy pointed to.",
+      "The Harpy chooses 2 players. :reminder: :reminder: Put the Harpy to sleep. Wake the 1st target. Show the *THIS CHARACTER SELECTED YOU* token, the Harpy token, then point to the 2nd target.",
     reminders: ['Mad', '2nd'],
     setup: false,
     ability:
@@ -1780,14 +1780,14 @@ export const roles = [
     team: 'minion',
     firstNight: 22,
     firstNightReminder:
-      'Select one of the good players next to the Demon and place the Is the Marionette reminder token. Wake the Demon and show them the Marionette.',
+      'Wake the Demon. Show the *THIS PLAYER IS* & Marionette tokens. Point to the Marionette.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
     remindersGlobal: ['Is the Marionette'],
     setup: true,
     ability:
-      'You think you are a good character but you are not. The Demon knows who you are. [You neighbour the Demon]',
+      'You think you are a good character, but you are not. The Demon knows who you are. [You neighbor the Demon]',
   },
   {
     id: 'mastermind',
@@ -1813,10 +1813,10 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNight: 41,
-    firstNightReminder: 'Show the Mezepheles their secret word.',
+    firstNightReminder: 'Show the secret word.',
     otherNight: 30,
     otherNightReminder:
-      "Wake the 1st good player that said the Mezepheles' secret word and show them the 'You are' card and the thumbs down evil signal.",
+      "If a good player said the secret word, wake the player. Show the *YOU ARE* info token & give a thumbs-down. :reminder: :reminder:",
     reminders: ['Turns evil', 'No ability'],
     setup: false,
     ability:
@@ -1832,11 +1832,11 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 27,
     otherNightReminder:
-      "The Pit-Hag points to a player and a character on the sheet. If this character is not in play, wake that player and show them the 'You are' card and the relevant character token. If the character is in play, nothing happens.",
+      "The Pit-Hag chooses a player & a character. If they chose a character that is not in play: Put the Pit-Hag to sleep. Wake the target. Show the *YOU ARE* token & their new character token.",
     reminders: [],
     setup: false,
     ability:
-      'Each night*, choose a player & a character they become (if not-in-play). If a Demon is made, deaths tonight are arbitrary.',
+      'Each night*, choose a player & a character they become (if not in play). If a Demon is made, deaths tonight are arbitrary.',
   },
   {
     id: 'poisoner',
@@ -1847,10 +1847,10 @@ export const roles = [
     team: 'minion',
     firstNight: 28,
     firstNightReminder:
-      'The Poisoner points to a player. That player is poisoned.',
+      'The Poisoner chooses a player. :reminder:',
     otherNight: 15,
     otherNightReminder:
-      'The previously poisoned player is no longer poisoned. The Poisoner points to a player. That player is poisoned.',
+      'The Poisoner chooses a player. :reminder:',
     reminders: ['Poisoned'],
     setup: false,
     ability:
@@ -1862,9 +1862,9 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      'Wake the Wraith tonight whenever other evil players wake.',
+      'Wake the Wraith whenever other evil players wake.',
     otherNightReminder:
-      'Wake the Wraith tonight whenever other evil players wake.',
+      'Wake the Wraith whenever other evil players wake.',
     reminders: [],
     special: [
       {
@@ -1908,11 +1908,11 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 31,
     otherNightReminder:
-      "If the Scarlet Woman became the Demon today: Show the 'You are' card, then the demon token.",
+      "If the Scarlet Woman became the Demon today, show them the *YOU ARE* token, then the Demon token.",
     reminders: ['Demon'],
     setup: false,
     ability:
-      'If there are 5 or more players alive & the Demon dies, you become the Demon. (travelers don’t count)',
+      'If there are 5 or more players alive & the Demon dies, you become the Demon. (Travellers don\'t count.)',
   },
   {
     id: 'spy',
@@ -1922,10 +1922,10 @@ export const roles = [
     team: 'minion',
     firstNight: 67,
     firstNightReminder:
-      'Show the Grimoire to the Spy for as long as they need.',
+      'Show the Grimoire for as long as the Spy needs.',
     otherNight: 89,
     otherNightReminder:
-      'Show the Grimoire to the Spy for as long as they need.',
+      'Show the Grimoire for as long as the Spy needs.',
     reminders: [],
     setup: false,
     ability:
@@ -1937,9 +1937,9 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      "Show the 'These characters are not in play' card. Show 3 character tokens of good characters not in play.",
+      "Show the *THESE CHARACTERS ARE NOT IN PLAY* token. Show 3 not-in-play good character tokens.",
     otherNightReminder:
-      'If it is the 3rd night, wake the Summoner. They point to a player and a Demon on the character sheet. That player becomes that Demon.',
+      'Change the Summoner reminder token to the relevant night. :reminder: If it is night 3, the Summoner chooses a player & a Demon character. Put the Summoner to sleep. Wake the target. Show the *YOU ARE* and Demon tokens & give a thumbs-down.',
     reminders: ['Night 1', 'Night 2', 'Night 3'],
     setup: true,
     ability:
@@ -1957,7 +1957,7 @@ export const roles = [
     name: 'Vizier',
     edition: '',
     team: 'minion',
-    firstNightReminder: 'Announce the Vizier player.',
+    firstNightReminder: 'Announce which player is the Vizier.',
     otherNightReminder: '',
     reminders: [],
     setup: false,
@@ -1978,14 +1978,14 @@ export const roles = [
     team: 'minion',
     firstNight: 29,
     firstNightReminder:
-      "Show the Grimoire to the Widow for as long as they need. The Widow points to a player. That player is poisoned. Wake a good player. Show the 'These characters are in play' card, then the Widow character token.",
+      "Show the Grimoire for as long as the Widow needs. The Widow chooses a player. :reminder: Put the Widow to sleep. Wake the player marked *KNOW* & show the Widow token. :reminder:",
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Poisoned'],
     remindersGlobal: ['Knows'],
     setup: false,
     ability:
-      'On your 1st night, look at the Grimoire and choose a player: they are poisoned. 1 good player knows a Widow is in play.',
+      'On your 1st night, look at the Grimoire & choose a player: they are poisoned. 1 good player knows a Widow is in play.',
   },
   {
     id: 'witch',
@@ -1995,10 +1995,10 @@ export const roles = [
     team: 'minion',
     firstNight: 37,
     firstNightReminder:
-      'The Witch points to a player. If that player nominates tomorrow they die immediately.',
+      'The Witch chooses a player. :reminder:',
     otherNight: 25,
     otherNightReminder:
-      'If there are 4 or more players alive: The Witch points to a player. If that player nominates tomorrow they die immediately.',
+      'The Witch chooses a player. :reminder:',
     reminders: ['Cursed'],
     setup: false,
     ability:
@@ -2010,9 +2010,9 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      "Add the Xaan's 'Night 1' reminder to the Grimoire. If X is 1, add the 'X' reminder.",
+      "If X is 1, mark the Xaan with the *X* reminder token. :reminder: :reminder:",
     otherNightReminder:
-      "Change the Xaan's night reminder to the relevant night. If tonight is night X, add the 'X' reminder.",
+      "Change the Xaan reminder token to the relevant night. If it is night X, mark the Xaan with the *X* reminder token. :reminder: :reminder:",
     reminders: ['Night 1', 'Night 2', 'Night 3', 'X'],
     setup: true,
     ability: 'On night X, all Townsfolk are poisoned until dusk. [X Outsiders]',
@@ -2033,11 +2033,11 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 49,
     otherNightReminder:
-      'The Al-Hadikhia chooses 3 players. Announce the first player, wake them to nod yes to live or shake head no to die, kill or resurrect accordingly, then put to sleep and announce the next player. If all 3 are alive after this, all 3 die.',
+      'The Al-Hadikhia chooses 3 players. :reminder: :reminder: :reminder: In order, wake each target. They nod or shake their head. Put them to sleep before waking the next target.',
     reminders: ['1', '2', '3', 'Chose death', 'Chose life'],
     setup: false,
     ability:
-      'Each night*, choose 3 players (all players learn who): each silently chooses to live or die, but if all live, all die.',
+      'Each night*, you may choose 3 players (all players learn who): each silently chooses to live or die, but if all live, all die.',
   },
   {
     id: 'yaggababble',
@@ -2046,11 +2046,11 @@ export const roles = [
     team: 'demon',
     firstNightReminder: 'Show the Yaggababble their secret phrase.',
     otherNightReminder:
-      'Choose a number of players up to the total number of times the Yaggababble publicly said their secret phrase today, those players die.',
+      'For each time the Yaggababble said their phrase today, a player might die. :reminder:',
     reminders: ['Mrtvý', 'Mrtvý', 'Mrtvý'],
     setup: false,
     ability:
-      'Začínáš s informací o tajném rčení. Za každé jeho veřejné vyslovení, které ve dne učiníš, může zemřít jeden hráč.',
+      'You start knowing a secret phrase. For each time you said it publicly today, a player might die.',
     image:
       'https://wiki.bloodontheclocktower.com/images/0/08/Icon_yaggababble.png',
     firstNight: 13,
@@ -2069,7 +2069,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 43,
     otherNightReminder:
-      "The Fang Gu points to a player. That player dies. Or, if that player was an Outsider and there are no other Fang Gu in play: The Fang Gu dies instead of the chosen player. The chosen player is now an evil Fang Gu. Wake the new Fang Gu. Show the 'You are' card, then the Fang Gu token. Show the 'You are' card, then the thumb-down 'evil' hand sign.",
+      "The Fang Gu chooses a player. :reminder: If they chose an Outsider (once only): Replace the Outsider token with the spare Fang Gu token. Put the Fang Gu to sleep. Wake the target. Show the *YOU ARE* and Fang Gu tokens & give a thumbs-down. :reminder:",
     reminders: ['Dead', 'Once'],
     setup: true,
     ability:
@@ -2085,7 +2085,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 38,
     otherNightReminder:
-      "The Imp points to a player. That player dies. If the Imp chose themselves: Replace the character of 1 alive minion with a spare Imp token. Show the 'You are' card, then the Imp token.",
+      "The Imp chooses a player. :reminder: If the Imp chose themselves: Replace 1 alive Minion token with a spare Imp token. Put the old Imp to sleep. Wake the new Imp. Show the *YOU ARE* token, then show the Imp token.",
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -2097,8 +2097,8 @@ export const roles = [
     edition: '',
     team: 'demon',
     firstNightReminder:
-      "The Kazali points to a player and a Minion on the character sheet. They do this for as many Minions as should be in play. Change those players' tokens to the chosen Minion tokens. Wake those players, show them the 'You Are' card, the Minions they have become, and a thumbs down.",
-    otherNightReminder: 'The Kazali points to a player. That player dies',
+      "The Kazali chooses which players are which Minions. Wake each target. Show the *YOU ARE* and Minion tokens & give a thumbs-down.",
+    otherNightReminder: 'The Kazali chooses a player. :reminder:',
     reminders: ['Dead'],
     setup: true,
     ability:
@@ -2119,7 +2119,7 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 37,
-    otherNightReminder: 'Choose a player, that player dies.',
+    otherNightReminder: 'A player might die. :reminder:',
     reminders: ['Dead', 'About to die'],
     setup: true,
     ability:
@@ -2134,9 +2134,9 @@ export const roles = [
     team: 'demon',
     firstNight: 74,
     firstNightReminder:
-      "Place the Leviathan 'Day 1' marker. Announce 'The Leviathan is in play; this is Day 1.'",
+      "Announce that the Leviathan is in play. :reminder:",
     otherNight: 95,
-    otherNightReminder: 'Change the Leviathan Day reminder for the next day.',
+    otherNightReminder: 'Change the Leviathan reminder token to the relevant day. :reminder: You may announce that the Leviathan is in play.',
     reminders: [
       'Day 1',
       'Day 2',
@@ -2147,7 +2147,7 @@ export const roles = [
     ],
     setup: false,
     ability:
-      'If more than 1 good player is executed, you win. All players know you are in play. After day 5, evil wins.',
+      'If more than 1 good player is executed, evil wins. All players know you are in play. After day 5, evil wins.',
   },
   {
     id: 'lilmonsta',
@@ -2158,15 +2158,15 @@ export const roles = [
     team: 'demon',
     firstNight: 25,
     firstNightReminder:
-      "Wake all Minions together, allow them to vote by pointing at who they want to babysit Lil' Monsta.",
+      "Wake the Minions. They choose a player. :reminder: Put the Minions to sleep. Wake the target. Show the *YOU ARE* & Lil' Monsta tokens.",
     otherNight: 51,
     otherNightReminder:
-      "Wake all Minions together, allow them to vote by pointing at who they want to babysit Lil' Monsta. Choose a player, that player dies.",
+      "Wake the Minions. They choose a player. :reminder: Put the Minions to sleep. Wake the target. Show the *YOU ARE* & Lil' Monsta tokens. A player might die. :reminder:",
     reminders: [],
     remindersGlobal: ['Is the Demon', 'Dead'],
     setup: true,
     ability:
-      'Each night, Minions choose who babysits Lil\' Monsta\'s token & "is the Demon". A player dies each night*. [+1 Minion]',
+      'Each night, Minions choose who babysits Lil\' Monsta & \\',
   },
   {
     id: 'lleech',
@@ -2176,13 +2176,13 @@ export const roles = [
     team: 'demon',
     firstNight: 26,
     firstNightReminder:
-      'The Lleech points to a player. Place the Poisoned reminder token.',
+      'The Lleech chooses a player. :reminder:',
     otherNight: 50,
-    otherNightReminder: 'The Lleech points to a player. That player dies.',
+    otherNightReminder: 'The Lleech chooses a player. :reminder:',
     reminders: ['Dead', 'Poisoned'],
     setup: false,
     ability:
-      'Each night*, choose a player: they die. You start by choosing an alive player: they are poisoned - you die if & only if they die.',
+      'Each night*, choose a player: they die. You start by choosing a player: they are poisoned. You die if & only if they are dead.',
   },
   {
     id: 'nodashii',
@@ -2194,11 +2194,11 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 44,
-    otherNightReminder: 'The No Dashii points to a player. That player dies.',
+    otherNightReminder: 'The No Dashii chooses a player. :reminder:',
     reminders: ['Dead', 'Poisoned'],
     setup: false,
     ability:
-      'Each night*, choose a player: they die. Your 2 Townsfolk neighbours are poisoned.',
+      'Each night*, choose a player: they die. Your 2 Townsfolk neighbors are poisoned.',
   },
   {
     id: 'ojo',
@@ -2207,7 +2207,7 @@ export const roles = [
     team: 'demon',
     firstNightReminder: '',
     otherNightReminder:
-      'The Ojo points to a character on the sheet. If it is in play, that player dies. If it is not in play, the Storyteller chooses who dies instead.',
+      'The Ojo chooses a character. :reminder:',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -2224,9 +2224,9 @@ export const roles = [
     edition: '',
     team: 'demon',
     firstNightReminder:
-      "Wake the players on either side of the Demon. Show them the 'You Are' card, the token of the Minion they now are, and a thumbs down to indicate they are evil.",
+      "Wake the Lord of Typhon's neighbors. Show the *YOU ARE* and Minion tokens & give a thumbs-down.",
     otherNightReminder:
-      'The Lord of Typhon points to a player. That player dies.',
+      'The Lord of Typhon chooses a player. :reminder:',
     reminders: ['Dead'],
     setup: true,
     ability:
@@ -2249,7 +2249,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 42,
     otherNightReminder:
-      "If the Po chose no-one the previous night: The Po points to three players. Otherwise: The Po either shows the 'no' head signal , or points to a player. Chosen players die",
+      "The Po may choose a player OR chooses 3 players if they chose no-one last night. :reminder: or :reminder: :reminder: :reminder:",
     reminders: ['Dead', '3 attacks'],
     setup: false,
     ability:
@@ -2263,10 +2263,10 @@ export const roles = [
     team: 'demon',
     firstNight: 42,
     firstNightReminder:
-      'The Pukka points to a player. That player is poisoned.',
+      'The Pukka chooses a player. :reminder:',
     otherNight: 40,
     otherNightReminder:
-      'The Pukka points to a player. That player is poisoned. The previously poisoned player dies. ',
+      'The Pukka chooses a player. :reminder: The previously poisoned player dies then becomes healthy. :reminder:',
     reminders: ['Poisoned', 'Dead'],
     setup: false,
     ability:
@@ -2281,11 +2281,11 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 0,
-    otherNightReminder: '',
+    otherNightReminder: 'Change the Riot reminder token to the relevant day. :reminder: If it is night 3, you may wake the Minions. Show the *YOU ARE* & Riot tokens.',
     reminders: [],
-    setup: true,
+    setup: false,
     ability:
-      'Nominees die, but may nominate again immediately (on day 3, they must). After day 3, evil wins. [All Minions are Riot]',
+      'On day 3, Minions become Riot & nominees die but nominate an alive player immediately. This must happen.',
   },
   {
     id: 'shabaloth',
@@ -2298,7 +2298,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 41,
     otherNightReminder:
-      'One player that the Shabaloth chose the previous night might be resurrected. The Shabaloth points to two players. Those players die.',
+      'A previously chosen player might be resurrected. :reminder: The Shabaloth chooses 2 players. :reminder: :reminder:',
     reminders: ['Dead', 'Alive'],
     setup: false,
     ability:
@@ -2315,11 +2315,11 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 47,
     otherNightReminder:
-      'The Vigormortis points to a player. That player dies. If a Minion, they keep their ability and one of their Townsfolk neighbours is poisoned.',
+      'The Vigormortis chooses a player. :reminder: If that player is a Minion, poison a neighboring Townsfolk. :reminder: :reminder:',
     reminders: ['Dead', 'Has ability', 'Poisoned'],
     setup: true,
     ability:
-      'Each night*, choose a player: they die. Minions you kill keep their ability & poison 1 Townsfolk neighbour. [−1 Outsider]',
+      'Each night*, choose a player: they die. Minions you kill keep their ability & poison 1 Townsfolk neighbor. [-1 Outsider]',
   },
   {
     id: 'vortox',
@@ -2330,7 +2330,7 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 45,
-    otherNightReminder: 'The Vortox points to a player. That player dies.',
+    otherNightReminder: 'The Vortox chooses a player. :reminder:',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -2346,7 +2346,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 39,
     otherNightReminder:
-      'If no-one died during the day: The Zombuul points to a player. That player dies.',
+      'If no one died today, the Zombuul chooses a player. :reminder:',
     reminders: ['Died today', 'Dead'],
     setup: false,
     ability:
@@ -2361,7 +2361,7 @@ export const roles = [
     team: 'traveler',
     firstNight: 5,
     firstNightReminder:
-      "Show the Apprentice the 'You are' card, then a Townsfolk or Minion token. In the Grimoire, replace the Apprentice token with that character token, and put the Apprentice's 'Is the Apprentice' reminder by that character token.",
+      "Show the *YOU ARE* info token, then a Townsfolk or Minion token. Swap the Apprentice & Townsfolk or Minion tokens. :reminder:",
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Is the Apprentice'],
@@ -2377,14 +2377,14 @@ export const roles = [
     team: 'traveler',
     firstNight: 6,
     firstNightReminder:
-      'Choose a player, wake them and tell them which Barista power is affecting them. Treat them accordingly (sober/healthy/true info or activate their ability twice).',
+      'Choose a player. Wake them, show the *THIS CHARACTER SELECTED YOU* & Barista tokens, then give a finger signal. :reminder:',
     otherNight: 4,
     otherNightReminder:
-      'Choose a player, wake them and tell them which Barista power is affecting them. Treat them accordingly (sober/healthy/true info or activate their ability twice).',
+      'Choose a player. Wake them, show the *THIS CHARACTER SELECTED YOU* & Barista tokens, then give a finger signal. :reminder:',
     reminders: ['Sober & Healthy', 'Ability twice'],
     setup: false,
     ability:
-      'Each night, until dusk, 1) a player becomes sober, healthy and gets true info, or 2) their ability works twice. They learn which.',
+      'Each night, until dusk, 1) a player becomes sober, healthy & gets true info, or 2) their ability works twice. They learn which.',
   },
   {
     id: 'beggar',
@@ -2399,7 +2399,7 @@ export const roles = [
     reminders: [],
     setup: false,
     ability:
-      'You must use a vote token to vote. Dead players may choose to give you theirs. If so, you learn their alignment. You are sober & healthy.',
+      'You must use a vote token to vote. If a dead player gives you theirs, you learn their alignment. You are sober & healthy.',
   },
   {
     id: 'bishop',
@@ -2414,7 +2414,7 @@ export const roles = [
     reminders: ['Nominate good', 'Nominate evil'],
     setup: false,
     ability:
-      'Only the Storyteller can nominate. At least 1 opposite player must be nominated each day.',
+      'Only the Storyteller can nominate. At least 1 opposing player must be nominated each day.',
   },
   {
     id: 'bonecollector',
@@ -2427,11 +2427,11 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 8,
     otherNightReminder:
-      "The Bone Collector either shakes their head no or points at any dead player. If they pointed at any dead player, put the Bone Collector's 'Has Ability' reminder by the chosen player's character token. (They may need to be woken tonight to use it.)",
+      "The Bone Collector might choose a dead player. :reminder: If necessary, wake the chosen player to use their ability.",
     reminders: ['No ability', 'Has ability'],
     setup: false,
     ability:
-      'Once per game, at night, choose a dead player: they regain their ability until dusk.',
+      'Once per game, at night*, choose a dead player: they regain their ability until dusk.',
   },
   {
     id: 'bureaucrat',
@@ -2442,10 +2442,10 @@ export const roles = [
     team: 'traveler',
     firstNight: 7,
     firstNightReminder:
-      "The Bureaucrat points to a player. Put the Bureaucrat's '3 votes' reminder by the chosen player's character token.",
+      "The Bureaucrat chooses a player. :reminder:",
     otherNight: 5,
     otherNightReminder:
-      "The Bureaucrat points to a player. Put the Bureaucrat's '3 votes' reminder by the chosen player's character token.",
+      "The Bureaucrat chooses a player. :reminder:",
     reminders: ['3 votes'],
     setup: false,
     ability:
@@ -2472,7 +2472,7 @@ export const roles = [
     team: 'traveler',
     firstNightReminder: '',
     otherNightReminder:
-      "Replace the character token of any player (besides the player the Cacklejack chose today) with a different character token. Wake that player and show them the 'You are' card and their new character token.",
+      "Before dawn, choose a player not marked *NOT ME*. Wake the target. Show the *YOU ARE* info token & their new character token.",
     reminders: ['Not Me'],
     setup: false,
     ability:
@@ -2511,7 +2511,7 @@ export const roles = [
     reminders: [],
     setup: false,
     ability:
-      'Once per day, you may choose to kill an alive neighbour, if your other alive neighbour agrees.',
+      'Once per day, you may choose to kill an alive neighbor, if your other alive neighbor agrees.',
   },
   {
     id: 'gnome',
@@ -2557,7 +2557,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 7,
     otherNightReminder:
-      "The Harlot points at any player. Then, put the Harlot to sleep. Wake the chosen player, show them the 'This character selected you' token, then the Harlot token. That player either nods their head yes or shakes their head no. If they nodded their head yes, wake the Harlot and show them the chosen player's character token. Then, you may decide that both players die.",
+      "The Harlot chooses a living player. Put the Harlot to sleep. Wake the chosen player, show them the *THIS CHARACTER SELECTED YOU* token, then the Harlot token. If that player nods their head, wake the Harlot and show them the chosen player's character token. Both players might die. :reminder: :reminder:",
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -2617,10 +2617,10 @@ export const roles = [
     team: 'traveler',
     firstNight: 8,
     firstNightReminder:
-      "The Thief points to a player. Put the Thief's 'Negative vote' reminder by the chosen player's character token.",
+      "The Thief chooses a player. :reminder:",
     otherNight: 6,
     otherNightReminder:
-      "The Thief points to a player. Put the Thief's 'Negative vote' reminder by the chosen player's character token.",
+      "The Thief chooses a player. :reminder:",
     reminders: ['Negative vote'],
     setup: false,
     ability:
@@ -2639,7 +2639,7 @@ export const roles = [
     reminders: [],
     setup: false,
     ability:
-      "Only you and the dead can vote. They don't need a vote token to do so. A 50% majority is not required.",
+      "Only you & the dead can vote. They don't need a vote token to do so. A 50% majority isn't required.",
   },
   {
     id: 'tor',
@@ -2648,9 +2648,9 @@ export const roles = [
     team: 'loric',
     firstNightReminder: '',
     otherNightReminder:
-      'If a player dies at night, wake them, show them the YOU ARE info token, their character token, the YOU ARE info token, and either a thumbs up or a thumbs down',
+      'If a player died tonight, show the *YOU ARE* info token, their character token, & a thumbs up or thumbs down.',
     reminders: [],
-    setup: false,
+    setup: true,
     ability:
       "Players don't know their character or alignment. They learn them when they die.",
     flavor:
@@ -2719,7 +2719,7 @@ export const roles = [
     team: 'loric',
     firstNight: 14,
     firstNightReminder:
-      'At the start of the night, announce which character is stormcaught. If that character is in play, mark that player as STORMCAUGHT.  Wake each evil player and show them the character token, then the marked player. If not in play, wake each evil player, show them the THESE CHARACTERS ARE NOT IN PLAY token and the relevant character token.',
+      'Announce which character is stormcaught. If that character is in play, mark that player as *STORMCAUGHT*. Wake each evil player and show them the character token, then the marked player.  If not in play, wake each evil player, show them the *THESE CHARACTERS ARE NOT IN PLAY* token & the relevant character token.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
@@ -2776,7 +2776,7 @@ export const roles = [
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
-    setup: false,
+    setup: true,
     ability: 'There are duplicate good characters in play. They might also be bluffs.',
     flavor: '',
     image: 'https://wiki.bloodontheclocktower.com/images/1/14/Icon_pope.png',
@@ -2799,7 +2799,7 @@ export const roles = [
   },
   {
     id: 'angel',
-    firstNightReminder: '',
+    firstNightReminder: 'Announce which players are protected by the Angel. :reminder:',
     otherNightReminder: '',
     reminders: ['Protect', 'Something Bad'],
     setup: false,
@@ -2814,7 +2814,7 @@ export const roles = [
   },
   {
     id: 'buddhist',
-    firstNightReminder: '',
+    firstNightReminder: 'Announce which players are affected by the Buddhist.',
     otherNightReminder: '',
     reminders: [],
     setup: false,
@@ -2856,7 +2856,7 @@ export const roles = [
     otherNight: 0,
     team: 'fabled',
     ability:
-      '2 neighboring players are known to be the same alignment. Once per game, one of them registers falsely.',
+      '2 neighboring players are known to be the same alignment. Once per game, 1 of them registers falsely.',
     image:
       'https://wiki.bloodontheclocktower.com/images/9/94/Icon_revolutionary.png',
   },
@@ -2877,10 +2877,10 @@ export const roles = [
   },
   {
     id: 'toymaker',
-    firstNightReminder: '',
+    firstNightReminder: 'Resolve Minion Info and Demon Info, even though there are fewer than 7 players.',
     otherNight: 1,
     otherNightReminder:
-      'If it is a night when a Demon attack could end the game, and the Demon is marked “Final night: No Attack,” then the Demon does not act tonight. (Do not wake them.)',
+      'If a Demon attack could end the game, and the Demon is marked *FINAL NIGHT: NO ATTACK*, do not wake the Demon.',
     reminders: ['Final Night: No Attack'],
     setup: false,
     name: 'Toymaker',
@@ -2903,7 +2903,7 @@ export const roles = [
     firstNight: 0,
     otherNight: 0,
     team: 'fabled',
-    ability: 'Once per game, 1 good player might get false information.',
+    ability: 'Once per game, 1 good player might get incorrect information.',
     image: 'https://wiki.bloodontheclocktower.com/images/2/2e/Icon_fibbin.png',
   },
   {
@@ -2911,7 +2911,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 1,
     otherNightReminder:
-      'Wake each player marked “Visitor” or “False Info” one at a time. Show them the Duchess token, then fingers (1, 2, 3) equaling the number of evil players marked “Visitor” or, if you are waking the player marked “False Info,” show them any number of fingers except the number of evil players marked “Visitor.”',
+      'One at a time: Wake each player marked *VISITOR* or *FALSE INFO*. Show the *THIS CHARACTER SELECTED YOU* & Duchess tokens, then give a finger signal.',
     reminders: ['Visitor', 'False Info'],
     setup: false,
     name: 'Duchess',
@@ -2976,9 +2976,9 @@ export const roles = [
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
-    setup: false,
+    setup: true,
     ability:
-      'At least once per game, the Storyteller will make a mistake, correct it, and publicly admit to it. ',
+      'At least once per game, the Storyteller will make a mistake, correct it, and publicly admit to it.',
     image:
       'https://wiki.bloodontheclocktower.com/images/7/71/Icon_deusexfiasco.png',
   },

--- a/apps/botc/src/data/roles.en.ts
+++ b/apps/botc/src/data/roles.en.ts
@@ -16,7 +16,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 11,
     firstNightReminder:
-      'Show the *YOU ARE* info token and a Minion token.',
+      'Show the YOU ARE info token and a Minion token.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
@@ -100,10 +100,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 61,
     firstNightReminder:
-      "Point to any player. :reminder:",
+      "Point to any player. ⏺",
     otherNight: 82,
     otherNightReminder:
-      "Point to a player with a different character type to the previously shown player. :reminder:",
+      "Point to a player with a different character type to the previously shown player. ⏺",
     reminders: [
       'Seen Townsfolk',
       'Seen Outsider',
@@ -124,10 +124,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 64,
     firstNightReminder:
-      "Point to the player marked *KNOW*. ",
+      "Point to the player marked KNOW. ",
     otherNight: 85,
     otherNightReminder:
-      'If the player marked *KNOW* died today or tonight, point to the new player marked *KNOW*.',
+      'If the player marked KNOW died today or tonight, point to the new player marked KNOW.',
     reminders: ['Known'],
     setup: true,
     ability:
@@ -225,10 +225,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 30,
     firstNightReminder:
-      "The Courtier might choose a character. :reminder: :reminder:",
+      "The Courtier might choose a character. ⏺ ⏺",
     otherNight: 16,
     otherNightReminder:
-      "The Courtier might choose a character. :reminder: :reminder:",
+      "The Courtier might choose a character. ⏺ ⏺",
     reminders: ['Drunk 3', 'Drunk 2', 'Drunk 1', 'No ability'],
     setup: false,
     ability:
@@ -243,10 +243,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 66,
     firstNightReminder:
-      'The Cult Leader might change alignment. If so, show the *YOU ARE* info token & give a thumb signal.',
+      'The Cult Leader might change alignment. If so, show the YOU ARE info token & give a thumb signal.',
     otherNight: 87,
     otherNightReminder:
-      'The Cult Leader might change alignment. If so, show the *YOU ARE* info token & give a thumb signal.',
+      'The Cult Leader might change alignment. If so, show the YOU ARE info token & give a thumb signal.',
     reminders: [],
     setup: false,
     ability:
@@ -295,10 +295,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 23,
     firstNightReminder:
-      "The Engineer might choose Minions or Demons. Put the Engineer to sleep. Wake the target(s) one at a time. Show the *YOU ARE* info token & their new character token. :reminder:",
+      "The Engineer might choose Minions or Demons. Put the Engineer to sleep. Wake the target(s) one at a time. Show the YOU ARE info token & their new character token. ⏺",
     otherNight: 12,
     otherNightReminder:
-      "The Engineer might choose Minions or Demons. Put the Engineer to sleep. Wake the target(s) one at a time. Show the *YOU ARE* info token & their new character token. :reminder:",
+      "The Engineer might choose Minions or Demons. Put the Engineer to sleep. Wake the target(s) one at a time. Show the YOU ARE info token & their new character token. ⏺",
     reminders: ['No ability'],
     setup: false,
     ability:
@@ -315,7 +315,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 34,
     otherNightReminder:
-      'The Exorcist chooses a player. :reminder: Put the Exorcist to sleep. If the Exorcist chose the Demon: Wake the Demon. Show the *THIS CHARACTER SELECTED YOU* & Exorcist tokens. Point to the Exorcist.',
+      'The Exorcist chooses a player. ⏺ Put the Exorcist to sleep. If the Exorcist chose the Demon: Wake the Demon. Show the THIS CHARACTER SELECTED YOU & Exorcist tokens. Point to the Exorcist.',
     reminders: ['Chosen'],
     setup: false,
     ability:
@@ -331,7 +331,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 68,
     otherNightReminder:
-      "If the Farmer died tonight, wake a living good player. Show the *YOU ARE* info token and a Farmer token.",
+      "If the Farmer died tonight, wake a living good player. Show the YOU ARE info token and a Farmer token.",
     reminders: [],
     setup: false,
     ability: 'When you die at night, an alive good player becomes a Farmer.',
@@ -391,10 +391,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 52,
     firstNightReminder:
-      'The Fortune Teller chooses 2 players. Nod if either is the Demon (or the *RED HERRING*).',
+      'The Fortune Teller chooses 2 players. Nod if either is the Demon (or the RED HERRING).',
     otherNight: 74,
     otherNightReminder:
-      "The Fortune Teller chooses 2 players. Nod if either is the Demon (or the *RED HERRING*).",
+      "The Fortune Teller chooses 2 players. Nod if either is the Demon (or the RED HERRING).",
     reminders: ['Red herring'],
     setup: false,
     ability:
@@ -410,7 +410,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 19,
     otherNightReminder:
-      'The Gambler chooses a player & a character. :reminder:',
+      'The Gambler chooses a player & a character. ⏺',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -443,7 +443,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 56,
     otherNightReminder:
-      'If the Gossip is due to kill a player, they die. :reminder:',
+      'If the Gossip is due to kill a player, they die. ⏺',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -461,7 +461,7 @@ export const roles = [
       'Point to the grandchild player & show their character token.',
     otherNight: 71,
     otherNightReminder:
-      'If the grandchild was killed by the Demon, the Grandmother dies too. :reminder:',
+      'If the grandchild was killed by the Demon, the Grandmother dies too. ⏺',
     reminders: ['Grandchild'],
     setup: false,
     ability:
@@ -476,10 +476,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 44,
     firstNightReminder:
-      "The Huntsman might choose a player. :reminder: If they chose the Damsel: Put the Huntsman to sleep. Wake the target. Show the *YOU ARE* info token & their new character token.",
+      "The Huntsman might choose a player. ⏺ If they chose the Damsel: Put the Huntsman to sleep. Wake the target. Show the YOU ARE info token & their new character token.",
     otherNight: 65,
     otherNightReminder:
-      "The Huntsman might choose a player. :reminder: If they chose the Damsel: Put the Huntsman to sleep. Wake the target. Show the *YOU ARE* info token & their new character token.",
+      "The Huntsman might choose a player. ⏺ If they chose the Damsel: Put the Huntsman to sleep. Wake the target. Show the YOU ARE info token & their new character token.",
     reminders: ['No ability'],
     setup: true,
     ability:
@@ -496,7 +496,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 17,
     otherNightReminder:
-      'The Innkeeper chooses 2 players. :reminder: :reminder: :reminder:',
+      'The Innkeeper chooses 2 players. ⏺ ⏺ ⏺',
     reminders: ['Protected', 'Drunk'],
     setup: false,
     ability:
@@ -511,7 +511,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 49,
     firstNightReminder:
-      'Show the Minion character token. Point to both the *MINION* and *WRONG* players.',
+      'Show the Minion character token. Point to both the MINION and WRONG players.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Minion', 'Wrong'],
@@ -542,7 +542,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 20,
     firstNightReminder:
-      "Wake the Demon: Show the *THIS PLAYER IS* & King tokens, then point to the King.",
+      "Wake the Demon: Show the THIS PLAYER IS & King tokens, then point to the King.",
     otherNight: 84,
     otherNightReminder:
       'If the dead equal or outnumber the living, show the character token of a living player.',
@@ -560,7 +560,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 48,
     firstNightReminder:
-      'Show the Outsider character token. Point to both the *OUTSIDER* and *WRONG* players.',
+      'Show the Outsider character token. Point to both the OUTSIDER and WRONG players.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Outsider', 'Wrong'],
@@ -579,7 +579,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 35,
     otherNightReminder:
-      'The Lycanthrope chooses a player. :reminder:',
+      'The Lycanthrope chooses a player. ⏺',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -660,7 +660,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 22,
     otherNightReminder:
-      "The Monk chooses a player. :reminder:",
+      "The Monk chooses a player. ⏺",
     reminders: ['Protected'],
     setup: false,
     ability:
@@ -675,10 +675,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 65,
     firstNightReminder:
-      "The Nightwatchman might choose a player. Put the Nightwatchman to sleep. Wake the target. Show the *THIS PLAYER IS* & Nightwatchman tokens, then point to the Nightwatchman. :reminder:",
+      "The Nightwatchman might choose a player. Put the Nightwatchman to sleep. Wake the target. Show the THIS PLAYER IS & Nightwatchman tokens, then point to the Nightwatchman. ⏺",
     otherNight: 86,
     otherNightReminder:
-      "The Nightwatchman might choose a player. Put the Nightwatchman to sleep. Wake the target. Show the *THIS PLAYER IS* & Nightwatchman tokens, then point to the Nightwatchman. :reminder:",
+      "The Nightwatchman might choose a player. Put the Nightwatchman to sleep. Wake the target. Show the THIS PLAYER IS & Nightwatchman tokens, then point to the Nightwatchman. ⏺",
     reminders: ['No ability'],
     setup: false,
     ability:
@@ -692,7 +692,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 60,
     firstNightReminder:
-      'Point to the 3 players marked *KNOW*.',
+      'Point to the 3 players marked KNOW.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Seen'],
@@ -738,10 +738,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 10,
     firstNightReminder:
-      "The Philosopher might choose a character. If necessary, swap their character token. :reminder:",
+      "The Philosopher might choose a character. If necessary, swap their character token. ⏺",
     otherNight: 9,
     otherNightReminder:
-      "The Philosopher might choose a character. If necessary, swap their character token. :reminder:",
+      "The Philosopher might choose a character. If necessary, swap their character token. ⏺",
     reminders: ['Drunk', 'Is the Philosopher'],
     setup: false,
     ability:
@@ -754,7 +754,7 @@ export const roles = [
     edition: '',
     team: 'townsfolk',
     firstNight: 43,
-    firstNightReminder: 'Show the Townsfolk character token marked *MAD*.',
+    firstNightReminder: 'Show the Townsfolk character token marked MAD.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Mad', 'Has ability'],
@@ -770,10 +770,10 @@ export const roles = [
     edition: '',
     team: 'townsfolk',
     firstNight: 12,
-    firstNightReminder: 'Skip Minion Info and Demon Info. Wake the Demon. Show the *THESE CHARACTERS ARE NOT IN PLAY* token. Show 3 not-in-play good character tokens.',
+    firstNightReminder: 'Skip Minion Info and Demon Info. Wake the Demon. Show the THESE CHARACTERS ARE NOT IN PLAY token. Show 3 not-in-play good character tokens.',
     otherNight: 10,
     otherNightReminder:
-      'If the Poppy Grower died today or tonight, wake all Minions. Show the *THIS IS THE DEMON* token. Point to the Demon. Put the Minions to sleep. Wake the Demon. Show the *THESE ARE YOUR MINIONS* token. Point to the Minions.',
+      'If the Poppy Grower died today or tonight, wake all Minions. Show the THIS IS THE DEMON token. Point to the Demon. Put the Minions to sleep. Wake the Demon. Show the THESE ARE YOUR MINIONS token. Point to the Minions.',
     reminders: ['Evil wakes'],
     setup: false,
     ability:
@@ -788,10 +788,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 24,
     firstNightReminder:
-      "The Preacher chooses a player. :reminder: If they chose a Minion: Put the Preacher to sleep. Wake the target. Show the *THIS CHARACTER SELECTED YOU* & Preacher tokens.",
+      "The Preacher chooses a player. ⏺ If they chose a Minion: Put the Preacher to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU & Preacher tokens.",
     otherNight: 13,
     otherNightReminder:
-      "The Preacher chooses a player. :reminder: If they chose a Minion: Put the Preacher to sleep. Wake the target. Show the *THIS CHARACTER SELECTED YOU* & Preacher tokens.",
+      "The Preacher chooses a player. ⏺ If they chose a Minion: Put the Preacher to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU & Preacher tokens.",
     reminders: ['At a sermon'],
     setup: false,
     ability:
@@ -804,7 +804,7 @@ export const roles = [
     team: 'townsfolk',
     firstNightReminder: '',
     otherNightReminder:
-      "If the Princess nominated the player who was executed today, wake the Demon as normal, but no one dies to the Demon's ability. :reminder:",
+      "If the Princess nominated the player who was executed today, wake the Demon as normal, but no one dies to the Demon's ability. ⏺",
     reminders: ["Doesn't Kill"],
     setup: false,
     ability:
@@ -826,7 +826,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 63,
     otherNightReminder:
-      'The Professor might choose a dead player. :reminder: :reminder:',
+      'The Professor might choose a dead player. ⏺ ⏺',
     reminders: ['Alive', 'No ability'],
     setup: false,
     ability:
@@ -854,7 +854,7 @@ export const roles = [
     name: 'Knight',
     edition: '',
     team: 'townsfolk',
-    firstNightReminder: 'Point to the 2 players marked *KNOW*.',
+    firstNightReminder: 'Point to the 2 players marked KNOW.',
     otherNightReminder: '',
     reminders: ['Know', 'Know'],
     setup: false,
@@ -888,10 +888,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 21,
     firstNightReminder:
-      'The Sailor chooses a living player. :reminder:',
+      'The Sailor chooses a living player. ⏺',
     otherNight: 11,
     otherNightReminder:
-      'The Sailor chooses a living player. :reminder:',
+      'The Sailor chooses a living player. ⏺',
     reminders: ['Drunk'],
     setup: false,
     ability:
@@ -921,10 +921,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 57,
     firstNightReminder:
-      "The Seamstress might choose 2 players. Nod or shake your head. :reminder:",
+      "The Seamstress might choose 2 players. Nod or shake your head. ⏺",
     otherNight: 80,
     otherNightReminder:
-      "The Seamstress might choose 2 players. Nod or shake your head. :reminder:",
+      "The Seamstress might choose 2 players. Nod or shake your head. ⏺",
     reminders: ['No ability'],
     setup: false,
     ability:
@@ -971,7 +971,7 @@ export const roles = [
     team: 'townsfolk',
     firstNightReminder: '',
     otherNightReminder:
-      'If the Banshee was killed by the Demon tonight, announce that the Banshee has died. :reminder:',
+      'If the Banshee was killed by the Demon tonight, announce that the Banshee has died. ⏺',
     reminders: ['Has Ability'],
     setup: false,
     ability:
@@ -992,10 +992,10 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 32,
     firstNightReminder:
-      'The Snake Charmer chooses a player. If they chose the Demon: Show the *YOU ARE* & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the *YOU ARE* and Snake Charmer tokens & give a thumbs up. :reminder:',
+      'The Snake Charmer chooses a player. If they chose the Demon: Show the YOU ARE & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the YOU ARE and Snake Charmer tokens & give a thumbs up. ⏺',
     otherNight: 21,
     otherNightReminder:
-      'The Snake Charmer chooses a player. If they chose the Demon: Show the *YOU ARE* & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the *YOU ARE* and Snake Charmer tokens & give a thumbs up. :reminder:',
+      'The Snake Charmer chooses a player. If they chose the Demon: Show the YOU ARE & Demon tokens. Give a thumbs down. Swap the Snake Charmer & Demon tokens. Put the old Snake Charmer to sleep. Wake the old Demon. Show the YOU ARE and Snake Charmer tokens & give a thumbs up. ⏺',
     reminders: ['Poisoned'],
     setup: false,
     ability:
@@ -1020,7 +1020,7 @@ export const roles = [
     name: 'Steward',
     edition: '',
     team: 'townsfolk',
-    firstNightReminder: 'Point to the player marked *KNOW*.',
+    firstNightReminder: 'Point to the player marked KNOW.',
     otherNightReminder: '',
     reminders: ['Know'],
     setup: false,
@@ -1103,7 +1103,7 @@ export const roles = [
     edition: '',
     team: 'townsfolk',
     firstNightReminder:
-      'If there are multiple Village Idiots, mark one as *DRUNK*. :reminder: Wake the Village Idiots one at a time to choose a player. Give a thumb signal.',
+      'If there are multiple Village Idiots, mark one as DRUNK. ⏺ Wake the Village Idiots one at a time to choose a player. Give a thumb signal.',
     otherNightReminder:
       'Wake the Village Idiots one at a time to choose a player. Give a thumb signal.',
     reminders: ['Drunk'],
@@ -1148,7 +1148,7 @@ export const roles = [
     team: 'townsfolk',
     firstNight: 47,
     firstNightReminder:
-      'Show the Townsfolk character token. Point to both the *TOWNSFOLK* and *WRONG* players.',
+      'Show the Townsfolk character token. Point to both the TOWNSFOLK and WRONG players.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Townsfolk', 'Wrong'],
@@ -1165,7 +1165,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 20,
     otherNightReminder:
-      'The Acrobat chooses a player. :reminder:',
+      'The Acrobat chooses a player. ⏺',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -1181,7 +1181,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 58,
     otherNightReminder:
-      "If the Barber died today or tonight, show the Demon the *THIS CHARACTER SELECTED YOU* & Barber tokens. If the Demon chose 2 players, wake one at a time. Show the *YOU ARE* token & their new character token.",
+      "If the Barber died today or tonight, show the Demon the THIS CHARACTER SELECTED YOU & Barber tokens. If the Demon chose 2 players, wake one at a time. Show the YOU ARE token & their new character token.",
     reminders: ['Haircuts tonight'],
     setup: false,
     ability:
@@ -1195,10 +1195,10 @@ export const roles = [
     team: 'outsider',
     firstNight: 53,
     firstNightReminder:
-      "The Butler chooses a player. :reminder:",
+      "The Butler chooses a player. ⏺",
     otherNight: 88,
     otherNightReminder:
-      "The Butler chooses a player. :reminder:",
+      "The Butler chooses a player. ⏺",
     reminders: ['Master'],
     setup: false,
     ability:
@@ -1212,10 +1212,10 @@ export const roles = [
     team: 'outsider',
     firstNight: 45,
     firstNightReminder:
-      "During Minion Info, show the Minions the Damsel token. If you haven't done this yet, do so now. If the Damsel was chosen by the Huntsman, show the *YOU ARE* info token & their new character token.",
+      "During Minion Info, show the Minions the Damsel token. If you haven't done this yet, do so now. If the Damsel was chosen by the Huntsman, show the YOU ARE info token & their new character token.",
     otherNight: 66,
     otherNightReminder:
-      "If the Damsel was chosen by the Huntsman, show the *YOU ARE* info token & their new character token.",
+      "If the Damsel was chosen by the Huntsman, show the YOU ARE info token & their new character token.",
     reminders: ['Guess used'],
     setup: false,
     ability:
@@ -1274,7 +1274,7 @@ export const roles = [
     team: 'outsider',
     firstNightReminder: '',
     otherNightReminder:
-      'If the Hatter died, wake the Minions & Demons. Each may choose a new character. If they do, show the *YOU ARE* token & their new character token.',
+      'If the Hatter died, wake the Minions & Demons. Each may choose a new character. If they do, show the YOU ARE token & their new character token.',
     reminders: ['Tea Party Tonight'],
     setup: false,
     ability:
@@ -1323,7 +1323,7 @@ export const roles = [
     team: 'outsider',
     firstNight: 17,
     firstNightReminder:
-      "If there are 7 or more players, wake the Lunatic: Show the *THESE ARE YOUR MINIONS* token. Point to any players. Show the *THESE CHARACTERS ARE NOT IN PLAY* token. Show 3 good character tokens. Put the Lunatic to sleep. Wake the Demon. Show the *YOU ARE* info token and the Demon token. Show the *THIS PLAYER IS* info token and the Lunatic token, then point to the Lunatic.",
+      "If there are 7 or more players, wake the Lunatic: Show the THESE ARE YOUR MINIONS token. Point to any players. Show the THESE CHARACTERS ARE NOT IN PLAY token. Show 3 good character tokens. Put the Lunatic to sleep. Wake the Demon. Show the YOU ARE info token and the Demon token. Show the THIS PLAYER IS info token and the Lunatic token, then point to the Lunatic.",
     otherNight: 33,
     otherNightReminder:
       "Do whatever needs to be done to simulate the Demon acting. Put the Lunatic to sleep. Wake the Demon. Show the Lunatic token & point to them, then their target(s).",
@@ -1343,7 +1343,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 70,
     otherNightReminder:
-      'If the Moonchild is due to kill a good player, they die. :reminder:',
+      'If the Moonchild is due to kill a good player, they die. ⏺',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -1355,7 +1355,7 @@ export const roles = [
     edition: '',
     team: 'outsider',
     firstNightReminder: '',
-    otherNightReminder: 'If the Plague Doctor died, the Storyteller gained a Minion ability. If you haven’t done this yet, do so now. :reminder:',
+    otherNightReminder: 'If the Plague Doctor died, the Storyteller gained a Minion ability. If you haven’t done this yet, do so now. ⏺',
     reminders: ['Storyteller Ability'],
     setup: false,
     ability: 'When you die, the Storyteller gains a Minion ability.',
@@ -1463,7 +1463,7 @@ export const roles = [
     team: 'outsider',
     firstNight: 16,
     firstNightReminder:
-      'Wake each Minion. Show the *THESE CHARACTERS ARE NOT IN PLAY* token. Show 3 not-in-play character tokens.',
+      'Wake each Minion. Show the THESE CHARACTERS ARE NOT IN PLAY token. Show 3 not-in-play character tokens.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
@@ -1480,7 +1480,7 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 59,
-    otherNightReminder: 'If the Sweetheart died, a player became drunk immediately. If you haven\'t done this yet, do so now. :reminder:',
+    otherNightReminder: 'If the Sweetheart died, a player became drunk immediately. If you haven\'t done this yet, do so now. ⏺',
     reminders: ['Drunk'],
     setup: false,
     ability: 'When you die, 1 player is drunk from now on.',
@@ -1494,7 +1494,7 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 69,
-    otherNightReminder: 'The Tinker might die. :reminder:',
+    otherNightReminder: 'The Tinker might die. ⏺',
     reminders: ['Dead'],
     setup: false,
     ability: 'You might die at any time.',
@@ -1523,7 +1523,7 @@ export const roles = [
     edition: '',
     team: 'outsider',
     firstNightReminder:
-      'The Ogre chooses a player. :reminder:',
+      'The Ogre chooses a player. ⏺',
     otherNightReminder: '',
     reminders: ['Friend'],
     setup: false,
@@ -1546,7 +1546,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 54,
     otherNightReminder:
-      "The Assassin might choose a player. :reminder: :reminder:",
+      "The Assassin might choose a player. ⏺ ⏺",
     reminders: ['Dead', 'No ability'],
     setup: false,
     ability:
@@ -1572,7 +1572,7 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      'Wake the Boffin and the Demon. Show the *THIS CHARACTER SELECTED YOU* & Boffin tokens, then the not-in-play good character token.',
+      'Wake the Boffin and the Demon. Show the THIS CHARACTER SELECTED YOU & Boffin tokens, then the not-in-play good character token.',
     otherNightReminder: '',
     reminders: [],
     setup: false,
@@ -1630,10 +1630,10 @@ export const roles = [
     team: 'minion',
     firstNight: 38,
     firstNightReminder:
-      "The Cerenovus chooses a player & a character. :reminder: Put the Cerenovus to sleep. Wake the target. Show the *THIS CHARACTER SELECTED YOU* token, the Cerenovus token, then the madness-character token.",
+      "The Cerenovus chooses a player & a character. ⏺ Put the Cerenovus to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU token, the Cerenovus token, then the madness-character token.",
     otherNight: 26,
     otherNightReminder:
-      "The Cerenovus chooses a player & a character. :reminder: Put the Cerenovus to sleep. Wake the target. Show the *THIS CHARACTER SELECTED YOU* token, the Cerenovus token, then the madness-character token.",
+      "The Cerenovus chooses a player & a character. ⏺ Put the Cerenovus to sleep. Wake the target. Show the THIS CHARACTER SELECTED YOU token, the Cerenovus token, then the madness-character token.",
     reminders: ['Mad'],
     setup: false,
     ability:
@@ -1645,9 +1645,9 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      "The Organ Grinder either nods their head yes to be drunk, or shakes their head no to be sober. :reminder:",
+      "The Organ Grinder either nods their head yes to be drunk, or shakes their head no to be sober. ⏺",
     otherNightReminder:
-      "The Organ Grinder either nods their head yes to be drunk, or shakes their head no to be sober. :reminder:",
+      "The Organ Grinder either nods their head yes to be drunk, or shakes their head no to be sober. ⏺",
     reminders: ['About To Die', 'Drunk'],
     special: [
       {
@@ -1675,10 +1675,10 @@ export const roles = [
     team: 'minion',
     firstNight: 35,
     firstNightReminder:
-      'The Devil\'s Advocate chooses a living player. :reminder:',
+      'The Devil\'s Advocate chooses a living player. ⏺',
     otherNight: 24,
     otherNightReminder:
-      'The Devil\'s Advocate chooses a living player. :reminder:',
+      'The Devil\'s Advocate chooses a living player. ⏺',
     reminders: ['Survives execution'],
     setup: false,
     ability:
@@ -1710,10 +1710,10 @@ export const roles = [
     team: 'minion',
     firstNight: 39,
     firstNightReminder:
-      'The Fearmonger chooses a player. :reminder: Announce that the Fearmonger has chosen a player.',
+      'The Fearmonger chooses a player. ⏺ Announce that the Fearmonger has chosen a player.',
     otherNight: 28,
     otherNightReminder:
-      'The Fearmonger chooses a player. :reminder: If the target is different to last night, announce that the Fearmonger has chosen a player.',
+      'The Fearmonger chooses a player. ⏺ If the target is different to last night, announce that the Fearmonger has chosen a player.',
     reminders: ['Fear'],
     setup: false,
     ability:
@@ -1745,7 +1745,7 @@ export const roles = [
     firstNightReminder: 'Show the character tokens of all in-play Outsiders.',
     otherNight: 55,
     otherNightReminder:
-      'If an Outsider died today, the Godfather chooses a player. :reminder:',
+      'If an Outsider died today, the Godfather chooses a player. ⏺',
     reminders: ['Died today', 'Dead'],
     setup: true,
     ability:
@@ -1757,9 +1757,9 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      "The Harpy chooses 2 players. :reminder: :reminder: Put the Harpy to sleep. Wake the 1st target. Show the *THIS CHARACTER SELECTED YOU* token, the Harpy token, then point to the 2nd target.",
+      "The Harpy chooses 2 players. ⏺ ⏺ Put the Harpy to sleep. Wake the 1st target. Show the THIS CHARACTER SELECTED YOU token, the Harpy token, then point to the 2nd target.",
     otherNightReminder:
-      "The Harpy chooses 2 players. :reminder: :reminder: Put the Harpy to sleep. Wake the 1st target. Show the *THIS CHARACTER SELECTED YOU* token, the Harpy token, then point to the 2nd target.",
+      "The Harpy chooses 2 players. ⏺ ⏺ Put the Harpy to sleep. Wake the 1st target. Show the THIS CHARACTER SELECTED YOU token, the Harpy token, then point to the 2nd target.",
     reminders: ['Mad', '2nd'],
     setup: false,
     ability:
@@ -1780,7 +1780,7 @@ export const roles = [
     team: 'minion',
     firstNight: 22,
     firstNightReminder:
-      'Wake the Demon. Show the *THIS PLAYER IS* & Marionette tokens. Point to the Marionette.',
+      'Wake the Demon. Show the THIS PLAYER IS & Marionette tokens. Point to the Marionette.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
@@ -1816,7 +1816,7 @@ export const roles = [
     firstNightReminder: 'Show the secret word.',
     otherNight: 30,
     otherNightReminder:
-      "If a good player said the secret word, wake the player. Show the *YOU ARE* info token & give a thumbs-down. :reminder: :reminder:",
+      "If a good player said the secret word, wake the player. Show the YOU ARE info token & give a thumbs-down. ⏺ ⏺",
     reminders: ['Turns evil', 'No ability'],
     setup: false,
     ability:
@@ -1832,7 +1832,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 27,
     otherNightReminder:
-      "The Pit-Hag chooses a player & a character. If they chose a character that is not in play: Put the Pit-Hag to sleep. Wake the target. Show the *YOU ARE* token & their new character token.",
+      "The Pit-Hag chooses a player & a character. If they chose a character that is not in play: Put the Pit-Hag to sleep. Wake the target. Show the YOU ARE token & their new character token.",
     reminders: [],
     setup: false,
     ability:
@@ -1847,10 +1847,10 @@ export const roles = [
     team: 'minion',
     firstNight: 28,
     firstNightReminder:
-      'The Poisoner chooses a player. :reminder:',
+      'The Poisoner chooses a player. ⏺',
     otherNight: 15,
     otherNightReminder:
-      'The Poisoner chooses a player. :reminder:',
+      'The Poisoner chooses a player. ⏺',
     reminders: ['Poisoned'],
     setup: false,
     ability:
@@ -1908,7 +1908,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 31,
     otherNightReminder:
-      "If the Scarlet Woman became the Demon today, show them the *YOU ARE* token, then the Demon token.",
+      "If the Scarlet Woman became the Demon today, show them the YOU ARE token, then the Demon token.",
     reminders: ['Demon'],
     setup: false,
     ability:
@@ -1937,9 +1937,9 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      "Show the *THESE CHARACTERS ARE NOT IN PLAY* token. Show 3 not-in-play good character tokens.",
+      "Show the THESE CHARACTERS ARE NOT IN PLAY token. Show 3 not-in-play good character tokens.",
     otherNightReminder:
-      'Change the Summoner reminder token to the relevant night. :reminder: If it is night 3, the Summoner chooses a player & a Demon character. Put the Summoner to sleep. Wake the target. Show the *YOU ARE* and Demon tokens & give a thumbs-down.',
+      'Change the Summoner reminder token to the relevant night. ⏺ If it is night 3, the Summoner chooses a player & a Demon character. Put the Summoner to sleep. Wake the target. Show the YOU ARE and Demon tokens & give a thumbs-down.',
     reminders: ['Night 1', 'Night 2', 'Night 3'],
     setup: true,
     ability:
@@ -1978,7 +1978,7 @@ export const roles = [
     team: 'minion',
     firstNight: 29,
     firstNightReminder:
-      "Show the Grimoire for as long as the Widow needs. The Widow chooses a player. :reminder: Put the Widow to sleep. Wake the player marked *KNOW* & show the Widow token. :reminder:",
+      "Show the Grimoire for as long as the Widow needs. The Widow chooses a player. ⏺ Put the Widow to sleep. Wake the player marked KNOW & show the Widow token. ⏺",
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Poisoned'],
@@ -1995,10 +1995,10 @@ export const roles = [
     team: 'minion',
     firstNight: 37,
     firstNightReminder:
-      'The Witch chooses a player. :reminder:',
+      'The Witch chooses a player. ⏺',
     otherNight: 25,
     otherNightReminder:
-      'The Witch chooses a player. :reminder:',
+      'The Witch chooses a player. ⏺',
     reminders: ['Cursed'],
     setup: false,
     ability:
@@ -2010,9 +2010,9 @@ export const roles = [
     edition: '',
     team: 'minion',
     firstNightReminder:
-      "If X is 1, mark the Xaan with the *X* reminder token. :reminder: :reminder:",
+      "If X is 1, mark the Xaan with the *X* reminder token. ⏺ ⏺",
     otherNightReminder:
-      "Change the Xaan reminder token to the relevant night. If it is night X, mark the Xaan with the *X* reminder token. :reminder: :reminder:",
+      "Change the Xaan reminder token to the relevant night. If it is night X, mark the Xaan with the *X* reminder token. ⏺ ⏺",
     reminders: ['Night 1', 'Night 2', 'Night 3', 'X'],
     setup: true,
     ability: 'On night X, all Townsfolk are poisoned until dusk. [X Outsiders]',
@@ -2033,7 +2033,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 49,
     otherNightReminder:
-      'The Al-Hadikhia chooses 3 players. :reminder: :reminder: :reminder: In order, wake each target. They nod or shake their head. Put them to sleep before waking the next target.',
+      'The Al-Hadikhia chooses 3 players. ⏺ ⏺ ⏺ In order, wake each target. They nod or shake their head. Put them to sleep before waking the next target.',
     reminders: ['1', '2', '3', 'Chose death', 'Chose life'],
     setup: false,
     ability:
@@ -2046,7 +2046,7 @@ export const roles = [
     team: 'demon',
     firstNightReminder: 'Show the Yaggababble their secret phrase.',
     otherNightReminder:
-      'For each time the Yaggababble said their phrase today, a player might die. :reminder:',
+      'For each time the Yaggababble said their phrase today, a player might die. ⏺',
     reminders: ['Mrtvý', 'Mrtvý', 'Mrtvý'],
     setup: false,
     ability:
@@ -2069,7 +2069,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 43,
     otherNightReminder:
-      "The Fang Gu chooses a player. :reminder: If they chose an Outsider (once only): Replace the Outsider token with the spare Fang Gu token. Put the Fang Gu to sleep. Wake the target. Show the *YOU ARE* and Fang Gu tokens & give a thumbs-down. :reminder:",
+      "The Fang Gu chooses a player. ⏺ If they chose an Outsider (once only): Replace the Outsider token with the spare Fang Gu token. Put the Fang Gu to sleep. Wake the target. Show the YOU ARE and Fang Gu tokens & give a thumbs-down. ⏺",
     reminders: ['Dead', 'Once'],
     setup: true,
     ability:
@@ -2085,7 +2085,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 38,
     otherNightReminder:
-      "The Imp chooses a player. :reminder: If the Imp chose themselves: Replace 1 alive Minion token with a spare Imp token. Put the old Imp to sleep. Wake the new Imp. Show the *YOU ARE* token, then show the Imp token.",
+      "The Imp chooses a player. ⏺ If the Imp chose themselves: Replace 1 alive Minion token with a spare Imp token. Put the old Imp to sleep. Wake the new Imp. Show the YOU ARE token, then show the Imp token.",
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -2097,8 +2097,8 @@ export const roles = [
     edition: '',
     team: 'demon',
     firstNightReminder:
-      "The Kazali chooses which players are which Minions. Wake each target. Show the *YOU ARE* and Minion tokens & give a thumbs-down.",
-    otherNightReminder: 'The Kazali chooses a player. :reminder:',
+      "The Kazali chooses which players are which Minions. Wake each target. Show the YOU ARE and Minion tokens & give a thumbs-down.",
+    otherNightReminder: 'The Kazali chooses a player. ⏺',
     reminders: ['Dead'],
     setup: true,
     ability:
@@ -2119,7 +2119,7 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 37,
-    otherNightReminder: 'A player might die. :reminder:',
+    otherNightReminder: 'A player might die. ⏺',
     reminders: ['Dead', 'About to die'],
     setup: true,
     ability:
@@ -2134,9 +2134,9 @@ export const roles = [
     team: 'demon',
     firstNight: 74,
     firstNightReminder:
-      "Announce that the Leviathan is in play. :reminder:",
+      "Announce that the Leviathan is in play. ⏺",
     otherNight: 95,
-    otherNightReminder: 'Change the Leviathan reminder token to the relevant day. :reminder: You may announce that the Leviathan is in play.',
+    otherNightReminder: 'Change the Leviathan reminder token to the relevant day. ⏺ You may announce that the Leviathan is in play.',
     reminders: [
       'Day 1',
       'Day 2',
@@ -2158,10 +2158,10 @@ export const roles = [
     team: 'demon',
     firstNight: 25,
     firstNightReminder:
-      "Wake the Minions. They choose a player. :reminder: Put the Minions to sleep. Wake the target. Show the *YOU ARE* & Lil' Monsta tokens.",
+      "Wake the Minions. They choose a player. ⏺ Put the Minions to sleep. Wake the target. Show the YOU ARE & Lil' Monsta tokens.",
     otherNight: 51,
     otherNightReminder:
-      "Wake the Minions. They choose a player. :reminder: Put the Minions to sleep. Wake the target. Show the *YOU ARE* & Lil' Monsta tokens. A player might die. :reminder:",
+      "Wake the Minions. They choose a player. ⏺ Put the Minions to sleep. Wake the target. Show the YOU ARE & Lil' Monsta tokens. A player might die. ⏺",
     reminders: [],
     remindersGlobal: ['Is the Demon', 'Dead'],
     setup: true,
@@ -2176,9 +2176,9 @@ export const roles = [
     team: 'demon',
     firstNight: 26,
     firstNightReminder:
-      'The Lleech chooses a player. :reminder:',
+      'The Lleech chooses a player. ⏺',
     otherNight: 50,
-    otherNightReminder: 'The Lleech chooses a player. :reminder:',
+    otherNightReminder: 'The Lleech chooses a player. ⏺',
     reminders: ['Dead', 'Poisoned'],
     setup: false,
     ability:
@@ -2194,7 +2194,7 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 44,
-    otherNightReminder: 'The No Dashii chooses a player. :reminder:',
+    otherNightReminder: 'The No Dashii chooses a player. ⏺',
     reminders: ['Dead', 'Poisoned'],
     setup: false,
     ability:
@@ -2207,7 +2207,7 @@ export const roles = [
     team: 'demon',
     firstNightReminder: '',
     otherNightReminder:
-      'The Ojo chooses a character. :reminder:',
+      'The Ojo chooses a character. ⏺',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -2224,9 +2224,9 @@ export const roles = [
     edition: '',
     team: 'demon',
     firstNightReminder:
-      "Wake the Lord of Typhon's neighbors. Show the *YOU ARE* and Minion tokens & give a thumbs-down.",
+      "Wake the Lord of Typhon's neighbors. Show the YOU ARE and Minion tokens & give a thumbs-down.",
     otherNightReminder:
-      'The Lord of Typhon chooses a player. :reminder:',
+      'The Lord of Typhon chooses a player. ⏺',
     reminders: ['Dead'],
     setup: true,
     ability:
@@ -2249,7 +2249,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 42,
     otherNightReminder:
-      "The Po may choose a player OR chooses 3 players if they chose no-one last night. :reminder: or :reminder: :reminder: :reminder:",
+      "The Po may choose a player OR chooses 3 players if they chose no-one last night. ⏺ or ⏺ ⏺ ⏺",
     reminders: ['Dead', '3 attacks'],
     setup: false,
     ability:
@@ -2263,10 +2263,10 @@ export const roles = [
     team: 'demon',
     firstNight: 42,
     firstNightReminder:
-      'The Pukka chooses a player. :reminder:',
+      'The Pukka chooses a player. ⏺',
     otherNight: 40,
     otherNightReminder:
-      'The Pukka chooses a player. :reminder: The previously poisoned player dies then becomes healthy. :reminder:',
+      'The Pukka chooses a player. ⏺ The previously poisoned player dies then becomes healthy. ⏺',
     reminders: ['Poisoned', 'Dead'],
     setup: false,
     ability:
@@ -2281,7 +2281,7 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 0,
-    otherNightReminder: 'Change the Riot reminder token to the relevant day. :reminder: If it is night 3, you may wake the Minions. Show the *YOU ARE* & Riot tokens.',
+    otherNightReminder: 'Change the Riot reminder token to the relevant day. ⏺ If it is night 3, you may wake the Minions. Show the YOU ARE & Riot tokens.',
     reminders: [],
     setup: false,
     ability:
@@ -2298,7 +2298,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 41,
     otherNightReminder:
-      'A previously chosen player might be resurrected. :reminder: The Shabaloth chooses 2 players. :reminder: :reminder:',
+      'A previously chosen player might be resurrected. ⏺ The Shabaloth chooses 2 players. ⏺ ⏺',
     reminders: ['Dead', 'Alive'],
     setup: false,
     ability:
@@ -2315,7 +2315,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 47,
     otherNightReminder:
-      'The Vigormortis chooses a player. :reminder: If that player is a Minion, poison a neighboring Townsfolk. :reminder: :reminder:',
+      'The Vigormortis chooses a player. ⏺ If that player is a Minion, poison a neighboring Townsfolk. ⏺ ⏺',
     reminders: ['Dead', 'Has ability', 'Poisoned'],
     setup: true,
     ability:
@@ -2330,7 +2330,7 @@ export const roles = [
     firstNight: 0,
     firstNightReminder: '',
     otherNight: 45,
-    otherNightReminder: 'The Vortox chooses a player. :reminder:',
+    otherNightReminder: 'The Vortox chooses a player. ⏺',
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -2346,7 +2346,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 39,
     otherNightReminder:
-      'If no one died today, the Zombuul chooses a player. :reminder:',
+      'If no one died today, the Zombuul chooses a player. ⏺',
     reminders: ['Died today', 'Dead'],
     setup: false,
     ability:
@@ -2361,7 +2361,7 @@ export const roles = [
     team: 'traveler',
     firstNight: 5,
     firstNightReminder:
-      "Show the *YOU ARE* info token, then a Townsfolk or Minion token. Swap the Apprentice & Townsfolk or Minion tokens. :reminder:",
+      "Show the YOU ARE info token, then a Townsfolk or Minion token. Swap the Apprentice & Townsfolk or Minion tokens. ⏺",
     otherNight: 0,
     otherNightReminder: '',
     reminders: ['Is the Apprentice'],
@@ -2377,10 +2377,10 @@ export const roles = [
     team: 'traveler',
     firstNight: 6,
     firstNightReminder:
-      'Choose a player. Wake them, show the *THIS CHARACTER SELECTED YOU* & Barista tokens, then give a finger signal. :reminder:',
+      'Choose a player. Wake them, show the THIS CHARACTER SELECTED YOU & Barista tokens, then give a finger signal. ⏺',
     otherNight: 4,
     otherNightReminder:
-      'Choose a player. Wake them, show the *THIS CHARACTER SELECTED YOU* & Barista tokens, then give a finger signal. :reminder:',
+      'Choose a player. Wake them, show the THIS CHARACTER SELECTED YOU & Barista tokens, then give a finger signal. ⏺',
     reminders: ['Sober & Healthy', 'Ability twice'],
     setup: false,
     ability:
@@ -2427,7 +2427,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 8,
     otherNightReminder:
-      "The Bone Collector might choose a dead player. :reminder: If necessary, wake the chosen player to use their ability.",
+      "The Bone Collector might choose a dead player. ⏺ If necessary, wake the chosen player to use their ability.",
     reminders: ['No ability', 'Has ability'],
     setup: false,
     ability:
@@ -2442,10 +2442,10 @@ export const roles = [
     team: 'traveler',
     firstNight: 7,
     firstNightReminder:
-      "The Bureaucrat chooses a player. :reminder:",
+      "The Bureaucrat chooses a player. ⏺",
     otherNight: 5,
     otherNightReminder:
-      "The Bureaucrat chooses a player. :reminder:",
+      "The Bureaucrat chooses a player. ⏺",
     reminders: ['3 votes'],
     setup: false,
     ability:
@@ -2472,7 +2472,7 @@ export const roles = [
     team: 'traveler',
     firstNightReminder: '',
     otherNightReminder:
-      "Before dawn, choose a player not marked *NOT ME*. Wake the target. Show the *YOU ARE* info token & their new character token.",
+      "Before dawn, choose a player not marked NOT ME. Wake the target. Show the YOU ARE info token & their new character token.",
     reminders: ['Not Me'],
     setup: false,
     ability:
@@ -2557,7 +2557,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 7,
     otherNightReminder:
-      "The Harlot chooses a living player. Put the Harlot to sleep. Wake the chosen player, show them the *THIS CHARACTER SELECTED YOU* token, then the Harlot token. If that player nods their head, wake the Harlot and show them the chosen player's character token. Both players might die. :reminder: :reminder:",
+      "The Harlot chooses a living player. Put the Harlot to sleep. Wake the chosen player, show them the THIS CHARACTER SELECTED YOU token, then the Harlot token. If that player nods their head, wake the Harlot and show them the chosen player's character token. Both players might die. ⏺ ⏺",
     reminders: ['Dead'],
     setup: false,
     ability:
@@ -2617,10 +2617,10 @@ export const roles = [
     team: 'traveler',
     firstNight: 8,
     firstNightReminder:
-      "The Thief chooses a player. :reminder:",
+      "The Thief chooses a player. ⏺",
     otherNight: 6,
     otherNightReminder:
-      "The Thief chooses a player. :reminder:",
+      "The Thief chooses a player. ⏺",
     reminders: ['Negative vote'],
     setup: false,
     ability:
@@ -2648,7 +2648,7 @@ export const roles = [
     team: 'loric',
     firstNightReminder: '',
     otherNightReminder:
-      'If a player died tonight, show the *YOU ARE* info token, their character token, & a thumbs up or thumbs down.',
+      'If a player died tonight, show the YOU ARE info token, their character token, & a thumbs up or thumbs down.',
     reminders: [],
     setup: true,
     ability:
@@ -2719,7 +2719,7 @@ export const roles = [
     team: 'loric',
     firstNight: 14,
     firstNightReminder:
-      'Announce which character is stormcaught. If that character is in play, mark that player as *STORMCAUGHT*. Wake each evil player and show them the character token, then the marked player.  If not in play, wake each evil player, show them the *THESE CHARACTERS ARE NOT IN PLAY* token & the relevant character token.',
+      'Announce which character is stormcaught. If that character is in play, mark that player as STORMCAUGHT. Wake each evil player and show them the character token, then the marked player.  If not in play, wake each evil player, show them the THESE CHARACTERS ARE NOT IN PLAY token & the relevant character token.',
     otherNight: 0,
     otherNightReminder: '',
     reminders: [],
@@ -2799,7 +2799,7 @@ export const roles = [
   },
   {
     id: 'angel',
-    firstNightReminder: 'Announce which players are protected by the Angel. :reminder:',
+    firstNightReminder: 'Announce which players are protected by the Angel. ⏺',
     otherNightReminder: '',
     reminders: ['Protect', 'Something Bad'],
     setup: false,
@@ -2911,7 +2911,7 @@ export const roles = [
     firstNightReminder: '',
     otherNight: 1,
     otherNightReminder:
-      'One at a time: Wake each player marked *VISITOR* or *FALSE INFO*. Show the *THIS CHARACTER SELECTED YOU* & Duchess tokens, then give a finger signal.',
+      'One at a time: Wake each player marked VISITOR or FALSE INFO. Show the THIS CHARACTER SELECTED YOU & Duchess tokens, then give a finger signal.',
     reminders: ['Visitor', 'False Info'],
     setup: false,
     name: 'Duchess',


### PR DESCRIPTION
## Summary
- Update abilities, night reminders, and setup flags to match the official script tool at script.bloodontheclocktower.com
- Strip `*UPPERCASE*` formatting markers from reminder text (the existing `formatReminder` function already bolds uppercase sequences)
- Replace `:reminder:` placeholder tokens with ⏺ character

216 fields updated across the role database.

## Test plan
- [ ] Verify night sheet renders correctly with updated reminder text
- [ ] Verify bold formatting still works for uppercase token names (e.g. THIS IS THE DEMON)
- [ ] Verify ⏺ renders at an appropriate size in the night sheet